### PR TITLE
Fix missing includes of <limits>

### DIFF
--- a/src/libbg/earcut.hpp
+++ b/src/libbg/earcut.hpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <limits>
 #include <memory>
 #include <vector>
 

--- a/src/libged/brep/brep.cpp
+++ b/src/libged/brep/brep.cpp
@@ -32,6 +32,7 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <list>
 #include <map>
 #include <queue>


### PR DESCRIPTION
Example compile error from gcc-11.1.0 on archlinux:
```
/home/jade/builds/brlcad/src/brlcad/src/libged/brep/brep.cpp: In function ‘int _brep_cmd_plate_mode(void*, int, const char*
*)’:
/home/jade/builds/brlcad/src/brlcad/src/libged/brep/brep.cpp:810:48: error: ‘numeric_limits’ is not a member of ‘std’
  810 |     ss << std::fixed << std::setprecision(std::numeric_limits<double>::max_digits10) << pthicknessmm;
      |                                                ^~~~~~~~~~~~~~
```