### PR TITLE
Annotation text segment extending

### DIFF
--- a/include/rt/geom.h
+++ b/include/rt/geom.h
@@ -987,6 +987,8 @@ struct txt_seg {
     int ref_pt;				/** reference point */
     int rel_pos;			/** flag describing position relative to ref_pt */
     struct bu_vls label;
+    fastf_t txt_size;           /** text size */
+    fastf_t txt_rot_angle;      /** text rotation angle */
 };
 
 /**

--- a/src/libged/typein/typein.c
+++ b/src/libged/typein/typein.c
@@ -638,7 +638,9 @@ static const char *p_annot[] = {
     "Enter X, Y for the text placement: ",
     "Enter Y: ",
     "Enter relative horizontal position (1->left, 2->center, 3->right): ",
-    "Enter relative vertical position (1->bottom, 2->middle, 3->top): "
+    "Enter relative vertical position (1->bottom, 2->middle, 3->top): ",
+    "Enter text size: ",
+    "Enter text angle: "
 };
 
 
@@ -3295,6 +3297,9 @@ annot_in(struct ged *gedp, const char **cmd_argvs, struct rt_db_internal *intern
     tsg->ref_pt = 0;
     bu_vls_init(&tsg->label);
     bu_vls_strcpy(&tsg->label, cmd_argvs[6]);
+    tsg->txt_size = atof(cmd_argvs[11]);
+    tsg->txt_rot_angle = atof(cmd_argvs[12]);
+
 
     BU_ALLOC(lsg, struct line_seg);
     lsg->magic = CURVE_LSEG_MAGIC;
@@ -3607,7 +3612,7 @@ ged_in_core(struct ged *gedp, int argc, const char *argv[])
 	menu = p_joint;
 	fn_in = joint_in;
     } else if (BU_STR_EQUAL(argv[2], "annot")) {
-	nvals = 3 + 1+ 2 + 2;
+	nvals = 3 + 1 + 2 + 2 + 2;
 	menu = p_annot;
 	fn_in = annot_in;
     } else if (BU_STR_EQUAL(argv[2], "script")) {

--- a/src/libged/typein/typein.c
+++ b/src/libged/typein/typein.c
@@ -3300,7 +3300,6 @@ annot_in(struct ged *gedp, const char **cmd_argvs, struct rt_db_internal *intern
     tsg->txt_size = atof(cmd_argvs[11]);
     tsg->txt_rot_angle = atof(cmd_argvs[12]);
 
-
     BU_ALLOC(lsg, struct line_seg);
     lsg->magic = CURVE_LSEG_MAGIC;
     lsg->start = 0;

--- a/src/librt/primitives/annot/annot.c
+++ b/src/librt/primitives/annot/annot.c
@@ -954,7 +954,6 @@ rt_annot_import5(struct rt_db_internal *ip, const struct bu_external *ep, const 
 		bu_cv_ntohd((unsigned char*)&scan, ptr, 1);
 		tsg->txt_size = scan;	/* double to fastf_t */
 		ptr += SIZEOF_NETWORK_DOUBLE;
-		scan = 0.0;
 		bu_cv_ntohd((unsigned char*)&scan, ptr, 1);
 		tsg->txt_rot_angle = scan;	/* double to fastf_t */
 		ptr += SIZEOF_NETWORK_DOUBLE;

--- a/src/librt/primitives/annot/annot.c
+++ b/src/librt/primitives/annot/annot.c
@@ -951,9 +951,12 @@ rt_annot_import5(struct rt_db_internal *ip, const struct bu_external *ep, const 
 		bu_vls_init(&tsg->label);
 		bu_vls_strcpy(&tsg->label, (const char*)ptr);
 		ptr += bu_vls_strlen(&tsg->label) + 1;
-		tsg->txt_size = ntohl(*(uint32_t*)ptr);
+		bu_cv_ntohd((unsigned char*)&scan, ptr, 1);
+		tsg->txt_size = scan;	/* double to fastf_t */
 		ptr += SIZEOF_NETWORK_DOUBLE;
-		tsg->txt_rot_angle = ntohl(*(uint32_t*)ptr);
+		scan = 0.0;
+		bu_cv_ntohd((unsigned char*)&scan, ptr, 1);
+		tsg->txt_rot_angle = scan;	/* double to fastf_t */
 		ptr += SIZEOF_NETWORK_DOUBLE;
 		annot_ip->ant.segments[seg_no] = (void *)tsg;
 		break;
@@ -1185,9 +1188,11 @@ rt_annot_export5(struct bu_external *ep, const struct rt_db_internal *ip, double
 		bu_strlcpy((char *)cp, bu_vls_addr(&tseg->label), bu_vls_strlen(&tseg->label) + 1);
 
 		cp += bu_vls_strlen(&tseg->label) + 1;
-		*(uint32_t*)cp = htonl(tseg->txt_size);
+		scan = tseg->txt_size;
+		bu_cv_htond(cp, (unsigned char*)&scan, 1);
 		cp += SIZEOF_NETWORK_DOUBLE;
-		*(uint32_t*)cp = htonl(tseg->txt_rot_angle);
+		scan = tseg->txt_rot_angle;
+		bu_cv_htond(cp, (unsigned char*)&scan, 1);
 		cp += SIZEOF_NETWORK_DOUBLE;
 		break;
 	    case CURVE_CARC_MAGIC:

--- a/src/librt/primitives/annot/annot.c
+++ b/src/librt/primitives/annot/annot.c
@@ -151,7 +151,7 @@ ant_label_dimensions(struct txt_seg* tsg, hpoint_t ref_pt, fastf_t* length, fast
     VSET(bmin, INFINITY, INFINITY, INFINITY);
     VSET(bmax, -INFINITY, -INFINITY, -INFINITY);
 
-    bv_vlist_2string(&vhead, &RTG.rtg_vlfree, tsg->label.vls_str, ref_pt[0], ref_pt[1], tsg->txt_rot_angle);
+    bv_vlist_2string(&vhead, &RTG.rtg_vlfree, tsg->label.vls_str, ref_pt[0], ref_pt[1], tsg->txt_size, tsg->txt_rot_angle);
     bv_vlist_bbox(&vhead, &bmin, &bmax, NULL, NULL);
 
     *length = bmax[0] - ref_pt[0];
@@ -453,7 +453,7 @@ seg_to_vlist(struct bu_list *vlfree, struct bu_list *vhead, const struct bg_tess
 	    }
 	    ant_pos_adjs(tsg, annot_ip);
 	    V2ADD2(pt, V, annot_ip->verts[tsg->ref_pt]);
-	    bv_vlist_2string(vhead, &RTG.rtg_vlfree, tsg->label.vls_str, pt[0], pt[1], tsg->txt_rot_angle);
+	    bv_vlist_2string(vhead, &RTG.rtg_vlfree, tsg->label.vls_str, pt[0], pt[1], tsg->txt_size, tsg->txt_rot_angle);
 	    break;
 	case CURVE_CARC_MAGIC:
 	    {


### PR DESCRIPTION
This is a patch to extend the text segment in the annotation primitive to have text size and text rotation angle parameters.
Reference to https://sourceforge.net/p/brlcad/patches/535/