### PR TITLE
Fix various typos

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1428,7 +1428,7 @@ s/bu_dirname\(/bu_path_dirname\(/g
 s/bu_basename\(/bu_path_basename\(/g
 s/bu_normalize\(/bu_path_normalize\(/g
 s/bu_argv_from_path\(/bu_path_to_argv\(/g
-        renamed path functons with proper group label [7.27]
+        renamed path functions with proper group label [7.27]
 s/bu_fnmatch\(/bu_path_match\(/g
 s/BU_FNMATCH_LEADING_DIR/0x0/g
 s/BU_FNMATCH_/BU_PATH_MATCH/g

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ list(APPEND CMAKE_MODULE_PATH "${BRLCAD_CMAKE_DIR}")
 # a potential source of subtle problems.  Bail with an explanation if
 # it is found to be present.
 if (EXISTS "${BRLCAD_SOURCE_DIR}/.gitattributes")
-  message(FATAL_ERROR "\nBRL-CAD does not use a .gitattributes file in its repository.  This is intended to prevent subtle errors from creeping in due to inadvertant pattern matches.  See ${BRLCAD_SOURCE_DIR}/doc/git/mime_types.txt for an in-depth discussion of the recommended alternatives to use for the problems .gitattributes is intended to address.\n")
+  message(FATAL_ERROR "\nBRL-CAD does not use a .gitattributes file in its repository.  This is intended to prevent subtle errors from creeping in due to inadvertent pattern matches.  See ${BRLCAD_SOURCE_DIR}/doc/git/mime_types.txt for an in-depth discussion of the recommended alternatives to use for the problems .gitattributes is intended to address.\n")
 endif (EXISTS "${BRLCAD_SOURCE_DIR}/.gitattributes")
 
 
@@ -128,7 +128,7 @@ else(NOT EXISTS ${BRLCAD_CNT_FILE})
   set(BRLCAD_PRINT_MSGS 0)
 endif(NOT EXISTS ${BRLCAD_CNT_FILE})
 
-# Now that we know whether or not we're supposed to, print the CMake verison
+# Now that we know whether or not we're supposed to, print the CMake version
 if(BRLCAD_PRINT_MSGS)
   message(STATUS "CMake version: ${CMAKE_VERSION}")
 endif(BRLCAD_PRINT_MSGS)
@@ -430,7 +430,7 @@ CONFIG_H_APPEND(BRLCAD "#define BRLCAD_DATA_DIR \"${DATA_DIR}\"\n")
 CONFIG_H_APPEND(BRLCAD "#define BRLCAD_DOC_DIR \"${DOC_DIR}\"\n")
 CONFIG_H_APPEND(BRLCAD "#define BRLCAD_MAN_DIR \"${MAN_DIR}\"\n")
 
-# Define the ammendment count if we have one
+# Define the amendment count if we have one
 if(DEFINED BRLCAD_VERSION_AMEND)
   CONFIG_H_APPEND(BRLCAD "#define BRLCAD_VERSION_AMEND ${BRLCAD_VERSION_AMEND}\n")
 endif(DEFINED BRLCAD_VERSION_AMEND)
@@ -2175,7 +2175,7 @@ foreach(ad ${ALL_DIRS})
   endif (DIR_TARGETS)
 endforeach(ad ${ALL_DIRS})
 
-# Now, set up the target dependencies for tiemstamp and buildtimedelta.  These
+# Now, set up the target dependencies for timestamp and buildtimedelta.  These
 # dependencies will produce a build-tool-independent ordering that gives us the
 # timing behavior we want.
 foreach(ctarget ${ALL_TARGETS})

--- a/INSTALL
+++ b/INSTALL
@@ -331,7 +331,7 @@ files.
 System PATH:
 
 Normally, BRL-CAD's install directories are not in system PATH lists and
-consequently BRL-CAD's executables will not be invokable without specifying
+consequently BRL-CAD's executables will not be invocable without specifying
 their full path.  This is normally handled in Unix environments by adding
 the desired BRL-CAD installation's binary directory to the user's local path:
 

--- a/NEWS
+++ b/NEWS
@@ -484,7 +484,7 @@ performance ray tracing pipeline.
 * added brlman -S option to specify man page section  - Cliff Yapp
 * modified rtg3 to avoid outputting excessive LOS - Nick Gerstner
 * extended burst and rtg3 to output 5 digit ID numbers - Nick Gerstner
-* improved draw command manual page documenation - Cliff Yapp
+* improved draw command manual page documentation - Cliff Yapp
 * added lc -m option to report multi-material/los regions - Cliff Yapp
 * added new 'icv' image conversion tool w/ pix, bw, dpix, png, ppm
 	- Mohit Daga, Cliff Yapp, Sean Morrison, Erik Greenwald

--- a/TODO
+++ b/TODO
@@ -104,7 +104,7 @@ THESE TASKS SHOULD HAPPEN WITHIN TWO RELEASE ITERATIONS
   duplicate entries.
 
 * tree command shouldn't infinite loop when encountering a cyclic
-  path - need to print a warning and stop walking.  Requries full
+  path - need to print a warning and stop walking.  Requires full
   path awareness in tree command walk.
 
   Consider implementing a corollary to FTS instead of dirent for
@@ -236,7 +236,7 @@ THESE ARE UNSCHEDULED BACKLOG TASKS
 
 * the osgl libdm backend has what appears to be an off-by-one-pixel
   error in the x and y directions with respect to mouse placement.
-  Using kmag, can see tha putting the mouse cursor over the center
+  Using kmag, can see that putting the mouse cursor over the center
   yellow dot and center clicking (which should be a no-op, and is
   with ogl) results in the scene shifting slightly.
 
@@ -1722,7 +1722,7 @@ NEW OBJECTS
   orthogonal vs perspective, ambient lighting levels, and possibly
   styling/render modes.
 
-  obviously need to be able to derive a homogenous transformation
+  obviously need to be able to derive a homogeneous transformation
   matrix, but may want to encode/preserve scale, translate, rotate
   with prescribed ordering separately for proper reversibility.
 

--- a/bench/benchmark.c
+++ b/bench/benchmark.c
@@ -393,7 +393,7 @@ main(int ac, char *av[])
 	bu_log("well-known datasets into 512x512 images where performance metrics are\n");
 	bu_log("documented and fairly well understood.  The local machine's\n");
 	bu_log("performance is compared to the base system (called VGR) and a numeric\n");
-	bu_log("\"VGR\" mulitplier of performance is computed.  This number is a\n");
+	bu_log("\"VGR\" multiplier of performance is computed.  This number is a\n");
 	bu_log("simplified metric from which one may qualitatively compare cpu and\n");
 	bu_log("cache performance, versions of BRL-CAD, and different compiler\n");
 	bu_log("characteristics.\n");
@@ -433,7 +433,7 @@ main(int ac, char *av[])
 	bu_log("effectively performing a multiplier amount of work over the initial\n");
 	bu_log("frame.\n");
 	bu_log("\n");
-	bu_log("Plese send your BRL-CAD Benchmark results to the developers along with\n");
+	bu_log("Please send your BRL-CAD Benchmark results to the developers along with\n");
 	bu_log("detailed system information to <devs@brlcad.org>.  Include at least:\n");
 	bu_log("\n");
 	bu_log("  0) Compiler name and version (e.g. gcc --version)\n");

--- a/doc/docbook/system/man1/burst.xml
+++ b/doc/docbook/system/man1/burst.xml
@@ -584,7 +584,7 @@ depth 52.88mm at (-418.907,-812.8,0) x-2 y1 lvl1 purpose=spall ray
 	<refsection xml:id="bursting_1_2_1">
 	  <title>Burst on Armor</title>
 	  <para>
-	    If the <command>burst-distance</command> paramter is set to a negative or zero value, then
+	    If the <command>burst-distance</command> parameter is set to a negative or zero value, then
 	    interior burst points will be generated (see <link linkend="bursting_2_1">Burst Distance</link>).
 	    This method of bursting requires the input of burst armor idents and, by default, burst
 	    air idents are also required. If the user does not want to require that certain air be

--- a/doc/docbook/system/man1/iges-g.xml
+++ b/doc/docbook/system/man1/iges-g.xml
@@ -43,7 +43,7 @@ combined into one BRL-CAD spline solid.
 The
 <option>-d</option>
 option indicates that IGES drawings should be converted to BRL-CAD NMG objects.
-Theses objects will be two-dimensional drawings, not solids.
+These objects will be two-dimensional drawings, not solids.
 The
 <option>-3</option>
 option is the same as the

--- a/doc/docbook/system/mann/facetize.xml
+++ b/doc/docbook/system/mann/facetize.xml
@@ -61,7 +61,7 @@
     <para>
       Creates <emphasis>new_object</emphasis> as planar primitive shape (either an NMG or a BOT)
       approximating the 3D volume bound by <emphasis>old_object</emphasis>.  The <emphasis>-r</emphasis>
-      option will operate per-region rather than on an entire object and produces a new hiearchy.
+      option will operate per-region rather than on an entire object and produces a new hierarchy.
     </para>
     <para>
       There are a number of different verbosity levels available for the facetize command.  One or mulitple specifications

--- a/doc/docbook/system/mann/get.xml
+++ b/doc/docbook/system/mann/get.xml
@@ -35,7 +35,7 @@
 
   <example><title>Elliptical Torus 'r' parameter extraction</title>
   <para>
-    Use the <command>get</command> command to exctract the
+    Use the <command>get</command> command to extract the
     r parameter value from an elliptical torus.
   </para>
 

--- a/doc/html/manuals/mged/ged.html
+++ b/doc/html/manuals/mged/ged.html
@@ -1798,7 +1798,7 @@ is the primitive type.
   editing.</p>
   <p>The parameter editing of the ELLG consists of scaling the
   lengths of the individual vectors A, B, C. One may also scale all
-  theses vectors together of equal length.</p>
+  these vectors together of equal length.</p>
   <p>The scaling of these vectors is done using the data
   tablet/mouse in exactly the same manner as in object scaling. The
   <i>p</i> keyboard command again can be used to produce a vector

--- a/doc/html/manuals/mged/ged.tex
+++ b/doc/html/manuals/mged/ged.tex
@@ -1992,7 +1992,7 @@ Figure \ref{ped-ell} depicts a typical ELLG during parameter editing.
 
 The parameter editing of the ELLG consists of scaling the lengths of the
 individual vectors A, B, C.
-One may also scale all theses vectors together of equal length.
+One may also scale all these vectors together of equal length.
 
 The scaling of these vectors is done using the data tablet/mouse in
 exactly the same manner as in object scaling.

--- a/doc/html/manuals/mged/shaders.html
+++ b/doc/html/manuals/mged/shaders.html
@@ -1228,7 +1228,7 @@ string.
       <a class="c1" name="testmap" id="testmap">testmap</a>
     </dt>
     <dd>Ramps the red value from off to on as the "u" coord of a
-    texture map varis fro m0 to 1, and the blue value with the "v"
+    texture map varies from m0 to 1, and the blue value with the "v"
     coordinate. For debugging.</dd>
     <dd>
       <h3>Parameters</h3>

--- a/doc/mged/d.tex
+++ b/doc/mged/d.tex
@@ -619,7 +619,7 @@ Figure \ref{ped-ell} depicts a typical ELLG during parameter editing.
 
 The parameter editing of the ELLG consists of scaling the lengths of the
 individual vectors A, B, C.
-One may also scale all theses vectors together of equal length.
+One may also scale all these vectors together of equal length.
 
 The scaling of these vectors is done using the data tablet/mouse in
 exactly the same manner as in object scaling.

--- a/doc/mged/g.tex
+++ b/doc/mged/g.tex
@@ -1270,7 +1270,7 @@ The use
 of the scale operation from the Solid Edit menu
 will result in the values of all the vectors being
 multiplied by the value of the scale.
-Use of the scale operaton from the Ellipsoid menu
+Use of the scale operation from the Ellipsoid menu
 with a particular vector A, B, or C changes the
 magnitude of that vector to the value of the scale.
 

--- a/doc/notes/cmake_paths/test.cmake.in
+++ b/doc/notes/cmake_paths/test.cmake.in
@@ -9,7 +9,7 @@ set(BIN_DIR "@BIN_DIR@")
 message(BIN_DIR:  ${BIN_DIR})
 
 # Using the above two pieces of information, construct the "root" path
-# below which the standard BRL-CAD file hiearchy (binary, library, data,
+# below which the standard BRL-CAD file hierarchy (binary, library, data,
 # doc, etc.) is built.
 string(REGEX REPLACE "${BIN_DIR}$" "" ROOT_DIR "${EXEC_DIR}")
 message(ROOT_DIR: ${ROOT_DIR})

--- a/include/analyze/info.h
+++ b/include/analyze/info.h
@@ -93,7 +93,7 @@ analyze_total_volume(struct current_state *context);
 
 /**
  * stores the region name, volume, high and low ranges of volume
- * for the specifed index of region in region table.
+ * for the specified index of region in region table.
  */
 ANALYZE_EXPORT extern void
 analyze_volume_region(struct current_state *context, int index, char** reg_name, double *volume, double *high, double *low);
@@ -112,7 +112,7 @@ analyze_total_mass(struct current_state *context);
 
 /**
  * stores the region name, mass, high and low ranges of mass
- * for the specifed index of region in region table.
+ * for the specified index of region in region table.
  */
 ANALYZE_EXPORT extern void
 analyze_mass_region(struct current_state *context, int index, char** reg_name, double *mass, double *high, double *low);
@@ -155,7 +155,7 @@ analyze_total_surf_area(struct current_state *state);
 
 /**
  * stores the region name, surf_area, high and low ranges of surf_area
- * for the specifed index of region in region table.
+ * for the specified index of region in region table.
  */
 ANALYZE_EXPORT extern void
 analyze_surf_area_region(struct current_state *state, int i, char **name, double *surf_area, double *high, double *low);

--- a/include/brlcad_ident.h.in
+++ b/include/brlcad_ident.h.in
@@ -25,7 +25,7 @@
  * They should use the library-specific LIBRARY_version() functions.
  * (e.g. bu_version())
  *
- * NOTE: In order to use compile-time API, applicaitons need to define
+ * NOTE: In order to use compile-time API, applications need to define
  * BRLCADBUILD and HAVE_CONFIG_H before including this header.
  */
 

--- a/include/brlcad_version.h.in
+++ b/include/brlcad_version.h.in
@@ -27,7 +27,7 @@
  * versioning.  Applications are encouraged to use library-specific
  * LIBRARY_version() functions.  (e.g. bu_version())
  *
- * NOTE: In order to use compile-time API, applicaitons need to define
+ * NOTE: In order to use compile-time API, applications need to define
  * BRLCADBUILD and HAVE_CONFIG_H before including this header.
  */
 

--- a/include/bu/defines.h
+++ b/include/bu/defines.h
@@ -180,7 +180,7 @@
 
 /**
  * shorthand declaration of a function that doesn't accept NULL
- * pointer arugments.  if a null pointer is detected during
+ * pointer arguments.  if a null pointer is detected during
  * compilation, a warning/error can be emitted.
  */
 #ifdef HAVE_NONNULL_ATTRIBUTE

--- a/include/bu/glob.h
+++ b/include/bu/glob.h
@@ -116,7 +116,7 @@ BU_EXPORT struct bu_glob_context *bu_glob_init();
 
 
 /**
- * release any resoures allocated during bu_glob(), including any
+ * release any resources allocated during bu_glob(), including any
  * returned paths
  */
 BU_EXPORT extern void bu_glob_free(struct bu_glob_context *);

--- a/include/common.h
+++ b/include/common.h
@@ -27,7 +27,7 @@
  * either detected via configure or hand crafted, as is the case for
  * the win32 platform.
  *
- * NOTE: In order to use compile-time API, applicaitons need to define
+ * NOTE: In order to use compile-time API, applications need to define
  * BRLCADBUILD and HAVE_CONFIG_H before including this header.
  *
  */
@@ -215,7 +215,7 @@ typedef ptrdiff_t ssize_t;
 
 /* off_t is 32 bit size even on 64 bit Windows. In the past we have tried to
  * force off_t to be 64 bit but this is failing on newer Windows/Visual Studio
- * verions in 2020 - therefore, we instead introduce the b_off_t define to
+ * versions in 2020 - therefore, we instead introduce the b_off_t define to
  * properly substitute the correct numerical type for the correct platform.  */
 #if defined(_WIN64)
 #  include <sys/stat.h>

--- a/include/dm/fbserv.h
+++ b/include/dm/fbserv.h
@@ -67,8 +67,8 @@ struct fbserv_listener {
 
 struct fbserv_client {
     int fbsc_fd;                        /**< @brief socket to send data down */
-    void *fbsc_chan;                    /**< @brief platform/tookit specific channel */
-    void *fbsc_handler;                 /**< @brief platform/tookit specific handler */
+    void *fbsc_chan;                    /**< @brief platform/toolkit specific channel */
+    void *fbsc_handler;                 /**< @brief platform/toolkit specific handler */
     struct pkg_conn *fbsc_pkg;
     struct fbserv_obj *fbsc_fbsp;       /**< @brief points to its fbserv object */
 };
@@ -82,10 +82,10 @@ struct fbserv_obj {
 
     int (*fbs_is_listening)(struct fbserv_obj *);          /**< @brief return 1 if listening, else 0 */
     int (*fbs_listen_on_port)(struct fbserv_obj *, int);  /**< @brief return 1 on success, 0 on failure */
-    void (*fbs_open_server_handler)(struct fbserv_obj *);   /**< @brief platform/tookit method to open listener handler */
-    void (*fbs_close_server_handler)(struct fbserv_obj *);   /**< @brief platform/tookit method to close handler listener */
-    void (*fbs_open_client_handler)(struct fbserv_obj *, int, void *);   /**< @brief platform/tookit specific client handler setup (called by fbs_new_client) */
-    void (*fbs_close_client_handler)(struct fbserv_obj *, int);   /**< @brief platform/tookit method to close handler for client at index client_id */
+    void (*fbs_open_server_handler)(struct fbserv_obj *);   /**< @brief platform/toolkit method to open listener handler */
+    void (*fbs_close_server_handler)(struct fbserv_obj *);   /**< @brief platform/toolkit method to close handler listener */
+    void (*fbs_open_client_handler)(struct fbserv_obj *, int, void *);   /**< @brief platform/toolkit specific client handler setup (called by fbs_new_client) */
+    void (*fbs_close_client_handler)(struct fbserv_obj *, int);   /**< @brief platform/toolkit method to close handler for client at index client_id */
 
     void (*fbs_callback)(void *);                  /**< @brief callback function */
     void *fbs_clientData;

--- a/include/ged/defines.h
+++ b/include/ged/defines.h
@@ -291,14 +291,14 @@ struct ged {
     /* fbserv server and I/O callbacks.  These must hook into the application's event
      * loop, and so cannot be effectively supplied by low-level libraries - the
      * application must tell us how to tie in with the toplevel event
-     * processing system it is using (typically tookit specific). */
+     * processing system it is using (typically toolkit specific). */
     struct fbserv_obj *ged_fbs;
     int (*fbs_is_listening)(struct fbserv_obj *);          /**< @brief return 1 if listening, else 0 */
     int (*fbs_listen_on_port)(struct fbserv_obj *, int);  /**< @brief return 1 on success, 0 on failure */
-    void (*fbs_open_server_handler)(struct fbserv_obj *);   /**< @brief platform/tookit method to open listener handler */
-    void (*fbs_close_server_handler)(struct fbserv_obj *);   /**< @brief platform/tookit method to close handler listener */
-    void (*fbs_open_client_handler)(struct fbserv_obj *, int, void *);   /**< @brief platform/tookit specific client handler setup (called by fbs_new_client) */
-    void (*fbs_close_client_handler)(struct fbserv_obj *, int);   /**< @brief platform/tookit method to close handler for client at index client_id */
+    void (*fbs_open_server_handler)(struct fbserv_obj *);   /**< @brief platform/toolkit method to open listener handler */
+    void (*fbs_close_server_handler)(struct fbserv_obj *);   /**< @brief platform/toolkit method to close handler listener */
+    void (*fbs_open_client_handler)(struct fbserv_obj *, int, void *);   /**< @brief platform/toolkit specific client handler setup (called by fbs_new_client) */
+    void (*fbs_close_client_handler)(struct fbserv_obj *, int);   /**< @brief platform/toolkit method to close handler for client at index client_id */
 
     // Other callbacks...
     // Tcl command strings - these are libtclcad level callbacks that execute user supplied Tcl commands if set:

--- a/include/nmg/edge.h
+++ b/include/nmg/edge.h
@@ -105,7 +105,7 @@ NMG_EXPORT extern void nmg_je(struct edgeuse *eudst,
  * If the original edge had edge geometry, that is *not* duplicated here,
  * because it is not easy (or appropriate) for nmg_eusplit() to know whether
  * the new vertex lies on the previous edge geometry or not.  Hence having the
- * nmg_ebreak() interface, which preserves the ege geometry across a split, and
+ * nmg_ebreak() interface, which preserves the edge geometry across a split, and
  * nmg_esplit() which does not.
  */
 NMG_EXPORT extern void nmg_unglueedge(struct edgeuse *eu);

--- a/include/rt/db4.h
+++ b/include/rt/db4.h
@@ -370,7 +370,7 @@ struct annot_rec {
     char	ant_id;			/*DBID_ANNOT */
     char	ant_pad;
     char	ant_name[NAMESIZE];
-    unsigned char	ant_V[8*3];		/* orgin map */
+    unsigned char	ant_V[8*3];		/* origin map */
     unsigned char       ant_vert_count[4];      /* number of vertices in annotation */
     unsigned char       ant_seg_count[4];       /* number of segments in annotation */
     unsigned char       ant_count[4];           /* number of additional granules */

--- a/regress/asc/asc.sh
+++ b/regress/asc/asc.sh
@@ -150,7 +150,7 @@ $DU $G4 $G5 2>&1 > $LOGFILE
 #log "$GD -v -t 0.0001 -F \"! -attr regionid_colortable\" $G3 $G5"
 #$GD -v -t 0.0001 -F "! -attr regionid_colortable" $G3 $G5 2>&1 > $LOGFILE
 #STATUS=$?
-# binary dbupdate should't have significantly altered the file.
+# binary dbupdate shouldn't have significantly altered the file.
 #if [ $STATUS -gt 0 ] ; then
 #    log "-> dbupgrade cycle FAILED, see $LOGFILE"
 #    cat "$LOGFILE"
@@ -161,7 +161,7 @@ $DU $G4 $G5 2>&1 > $LOGFILE
 # all the processing should be identical
 #
 # (Well, unchanged sans a region color table, region_id=-1 on all.g and
-# numerical differences anyway... Accomidate data changes with gdiff
+# numerical differences anyway... Accommodate data changes with gdiff
 # filtering.)
 log "$GD -v -t 0.0001 -F \"! -name _GLOBAL ! -attr region_id=-1\" $G1 $G5"
 $GD -v -t 0.0001 -F "! -name _GLOBAL ! -attr region_id=-1" $G1 $G5 2>&1 > $LOGFILE

--- a/regress/dsp/CMakeLists.txt
+++ b/regress/dsp/CMakeLists.txt
@@ -5,7 +5,7 @@ if (SH_EXEC AND TARGET mged)
     BRLCAD_ADD_TEST(NAME regress-dsp COMMAND ${SH_EXEC} "${CMAKE_CURRENT_SOURCE_DIR}/dsp.sh" ${CMAKE_SOURCE_DIR})
     BRLCAD_REGRESSION_TEST(regress-dsp "mged;cv;asc2pix;rt;pix-bw" TEST_DEFINED)
   else (NOT WIN32)
-    message(WARNING "regress-dsp failes on some Windows platforms (pix-bw appears to hang on github runners) - skipping")
+    message(WARNING "regress-dsp fails on some Windows platforms (pix-bw appears to hang on github runners) - skipping")
   endif (NOT WIN32)
 
 endif (SH_EXEC AND TARGET mged)

--- a/regress/gcv/vrml/vrml_example.wrl
+++ b/regress/gcv/vrml/vrml_example.wrl
@@ -2,7 +2,7 @@
 #-----------------------------------------------------------------------------
 # vrml_example.wrl
 #
-# Trival VRML scene based on info from
+# Trvial VRML scene based on info from
 # https://cs.lmu.edu/~ray/notes/vrmlexamples/
 #-----------------------------------------------------------------------------
 Transform {

--- a/regress/ged/push.cpp
+++ b/regress/ged/push.cpp
@@ -141,7 +141,7 @@ main(int argc, const char **argv)
 	gargv[gargc-2] = NULL;
     }
 
-    // To avoid problems with bu_argv_free, make very sure the last two entires
+    // To avoid problems with bu_argv_free, make very sure the last two entries
     // are not pointing to something else.
     gargv[gargc-2] = NULL;
     gargv[gargc-1] = NULL;

--- a/regress/mged/mged.sh
+++ b/regress/mged/mged.sh
@@ -99,7 +99,7 @@ check_command ( ) {
     return 0
 }
 
-log "seting up an almost empty database (mged.g) to make sure mged runs"
+log "setting up an almost empty database (mged.g) to make sure mged runs"
 rm -f mged.g
 $MGED -c >> $LOGFILE 2>&1 <<EOF
 opendb mged.g y

--- a/regress/user/CMakeLists.txt
+++ b/regress/user/CMakeLists.txt
@@ -17,7 +17,7 @@ set_property(DIRECTORY PROPERTY INCLUDE_DIRECTORIES "")
 
 # We deliberately do not use any of the BRL-CAD wrapper functions such as
 # BRLCAD_ADDEXEC in order to avoid their automatic addtiion of compile
-# defintions or other magic specific to BRL-CAD's internal build.
+# definitions or other magic specific to BRL-CAD's internal build.
 add_executable(cad_user cad_user.c)
 target_link_libraries(cad_user libged)
 add_dependencies(cad_user managed_files)

--- a/regress/user/regress-user.cmake.in
+++ b/regress/user/regress-user.cmake.in
@@ -20,7 +20,7 @@ get_filename_component(BDIR "${USER_EXEC}" DIRECTORY)
 string(REGEX REPLACE "${BIN_DIR}$" "" RDIR "${BDIR}")
 set(GFILE "${RDIR}/${DATA_DIR}/db/moss.g")
 
-# Runn the command
+# Run the command
 file(APPEND "${LOGFILE}" "Running ${USER_EXEC} ${GFILE}:\n")
 execute_process(
   COMMAND "${USER_EXEC}" "${GFILE}"

--- a/src/conv/patch/patch-g.c
+++ b/src/conv/patch/patch-g.c
@@ -1071,7 +1071,7 @@ proc_region(char *name1)
 	mir_count = 0;
     }
 
-    /* explicitely shorten tmpname to quell the gcc 8.2 snprintf string length warning/error */
+    /* explicitly shorten tmpname to quell the gcc 8.2 snprintf string length warning/error */
     bu_strlcpy(tmpname2, tmpname, sizeof(tmpname2));
 
     if (cc != in[0].cc) {

--- a/src/libbu/tests/semchk.cpp
+++ b/src/libbu/tests/semchk.cpp
@@ -192,7 +192,7 @@ validate_semaphores(std::map<std::string, std::string> *sem_defs, int verbose)
 		errno = 0;
 		ninc = strtol(einc.c_str(), &endptr, 0);
 		if ((endptr != NULL && strlen(endptr) > 0) || errno == ERANGE) {
-		    std::cerr << "Could not evalute expression number: " << einc << "\n";
+		    std::cerr << "Could not evaluate expression number: " << einc << "\n";
 		    exit(1);
 		}
 


### PR DESCRIPTION
Found via `codespell -q 3 -L acount,aray,ba,childs,comando,desig,fo,mater,nd,ocur,pard,survice`