### PR TITLE
Nirt options cleanup when run within mged

### DIFF
--- a/TODO
+++ b/TODO
@@ -126,8 +126,6 @@ THESE TASKS SHOULD HAPPEN WITHIN TWO RELEASE ITERATIONS
 * heap unit test needs to actually compare performance against system
   allocation, not just do some work
 
-* mged> nirt -? needs to provide help
-
 * mged> nirt -f fmt doesn't seem to work at all
 
 * move the rt_*_timer timing facilities to libbu and rework to allow

--- a/TODO
+++ b/TODO
@@ -126,7 +126,8 @@ THESE TASKS SHOULD HAPPEN WITHIN TWO RELEASE ITERATIONS
 * heap unit test needs to actually compare performance against system
   allocation, not just do some work
 
-* mged> nirt -f fmt doesn't seem to work at all
+* mged> nirt -f fmt needs output cleanup. When run with -f csv there are 
+  unexpected warnings and duplicate line prints
 
 * move the rt_*_timer timing facilities to libbu and rework to allow
   contexts, allowing for more than one timer to be active.  Make sure


### PR DESCRIPTION
nirt help is now useful and prints using src/nirt. The fix applies to all commands which solely print information to the users (ie -L)
Some work on -f fmt is wrapped in as well. Option is now recognized, but needs format cleanup. 