### PR TITLE
fixed an issue, where the linkage of static libraries gives multiple XXH_~ definitions

### DIFF
--- a/src/libbn/mat.c
+++ b/src/libbn/mat.c
@@ -34,6 +34,7 @@
 #include <string.h>
 #define XXH_STATIC_LINKING_ONLY
 #define XXH_IMPLEMENTATION
+#define XXH_PRIVATE_API
 #include "xxhash.h"
 #include "bio.h"
 

--- a/src/libged/display_list.c
+++ b/src/libged/display_list.c
@@ -37,6 +37,8 @@
 #include "ged.h"
 #include "./ged_private.h"
 
+#define XXH_STATIC_LINKING_ONLY
+#define XXH_IMPLEMENTATION
 #include "xxhash.h"
 
 #define LAST_SOLID(_sp)       DB_FULL_PATH_CUR_DIR( &(_sp)->s_fullpath )

--- a/src/libged/draw.cpp
+++ b/src/libged/draw.cpp
@@ -34,6 +34,7 @@
 #include <time.h>
 #include "bsocket.h"
 
+#define XXH_STATIC_LINKING_ONLY
 #include "xxhash.h"
 
 #include "bu/cmd.h"

--- a/src/libged/vutil.c
+++ b/src/libged/vutil.c
@@ -25,8 +25,8 @@
 
 #include "common.h"
 
+#include <string.h>
 #define XXH_STATIC_LINKING_ONLY
-#define XXH_IMPLEMENTATION
 #include "xxhash.h"
 
 #include "./ged_private.h"


### PR DESCRIPTION
at the end, libged still exports the XXH stuff, but defining XXH_PRIVATE_API there would require to have XXH_IMPLEMENTATION in every file where it's used