### PR TITLE
Add metainfo for BRL-CAD

### DIFF
--- a/misc/debian/archer.desktop
+++ b/misc/debian/archer.desktop
@@ -5,5 +5,5 @@ Comment=Archer - Constructive solid geometry (CSG) solid modeling computer-aided
 Exec=bash -c "cd /usr/brlcad/bin/ && /usr/brlcad/bin/archer %f"
 Icon=archer
 Type=Application
-Categories=BRL-CAD;
+Categories=Graphics;Science;Education;Engineering;
 MimeType=application/brlcad-v4;application/brlcad-v5;

--- a/misc/debian/brlcad-db.desktop
+++ b/misc/debian/brlcad-db.desktop
@@ -5,4 +5,4 @@ Comment=BRL-CAD Database examples
 Exec=xdg-open /usr/brlcad/share/db
 Icon=brlcad-db
 Type=Application
-Categories=BRL-CAD-doc;
+Categories=Graphics;Science;Education;Engineering;

--- a/misc/debian/brlcad-doc-mged.desktop
+++ b/misc/debian/brlcad-doc-mged.desktop
@@ -5,4 +5,4 @@ Comment=MGED geometry editor manual
 Exec=xdg-open /usr/brlcad/share/doc/html/manuals/mged/index.html
 Icon=brlcad-doc
 Type=Application
-Categories=BRL-CAD-doc;
+Categories=Graphics;Science;Education;Engineering;

--- a/misc/debian/brlcad-doc.desktop
+++ b/misc/debian/brlcad-doc.desktop
@@ -5,4 +5,4 @@ Comment=BRL-CAD Articles, Books and Lessons
 Exec=xdg-open /usr/brlcad/share/doc/html/toc.html
 Icon=brlcad-doc
 Type=Application
-Categories=BRL-CAD-doc;
+Categories=Graphics;Science;Education;Engineering;

--- a/misc/debian/org.brlcad.BRL_CAD.metainfo.xml
+++ b/misc/debian/org.brlcad.BRL_CAD.metainfo.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+    <id>org.brlcad.BRL_CAD</id>
+    <launchable type="desktop-id">org.brlcad.BRL_CAD.desktop</launchable>
+    <name>BRL-CAD</name>
+    <summary>Open source combinatorial solid modeling system</summary>
+    <metadata_license>CC0-1.0</metadata_license>
+    <project_license>LGPL-2.1-only</project_license>
+    <description>
+        <p>
+            BRL-CAD is a powerful cross-platform open source combinatorial
+            solid modeling system that includes an interactive 3D solid geometry
+            editor, a network-distributed symmetric multiprocessing (SMP)
+            high-performance ray-tracer with support for rendering and geometric
+            analysis, image and signal-processing tools, a system performance
+            analysis benchmark suite, a flexible geometry scripting interface,
+            and a high-performance geometric representation and analysis library.
+        </p>
+    </description>
+    <screenshots>
+        <screenshot type="default">
+            <image>https://brlcad.org/gallery/galleries/screenshots/Via_OpenBook_part_d.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://brlcad.org/gallery/galleries/screenshots/ronja_screenshot.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://brlcad.org/gallery/_data/i/galleries/screenshots/gnu_tux-xx.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://brlcad.org/gallery/galleries/screenshots/puget_mged.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://brlcad.org/gallery/galleries/screenshots/t62_mged.jpg</image>
+        </screenshot>
+        <screenshot>
+            <image>https://brlcad.org/gallery/galleries/screenshots/cassini-1.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://brlcad.org/gallery/galleries/screenshots/Archer_0_5prototype.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://brlcad.org/gallery/_data/i/galleries/screenshots/extractor-xx.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://brlcad.org/gallery/galleries/screenshots/cassini-glass-titan.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://brlcad.org/gallery/_data/i/galleries/screenshots/MGED-xx.jpg</image>
+        </screenshot>
+    </screenshots>
+  <url type="homepage">https://brlcad.org/</url>
+  <url type="help">https://brlcad.org/wiki/Main_Page</url>
+  <url type="bugtracker">https://github.com/BRL-CAD/brlcad/issues</url>
+  <content_rating type="oars-1.1"/>
+  <releases>
+      <release version="7.34.2" date="2023-05-22"/>
+      <release version="7.34.0" date="2022-11-29"/>
+  </releases>
+</component>

--- a/misc/debian/org.brlcad.BRL_CAD.metainfo.xml
+++ b/misc/debian/org.brlcad.BRL_CAD.metainfo.xml
@@ -54,7 +54,7 @@
   <url type="bugtracker">https://github.com/BRL-CAD/brlcad/issues</url>
   <content_rating type="oars-1.1"/>
   <releases>
-      <release version="7.34.2" date="2023-05-22"/>
-      <release version="7.34.0" date="2022-11-29"/>
+      <release version="7-34-2" date="2023-05-22"/>
+      <release version="7-34-0" date="2022-11-29"/>
   </releases>
 </component>


### PR DESCRIPTION
This meta file adds information about the project that is useful for the software distribution platform to display useful information to the user. This is part of my effort to package BRL-CAD as Flatpak for Linux distros.

Change categories in desktop file to match specification https://specifications.freedesktop.org/menu-spec/latest/apa.html