### PR TITLE
Updates to trimesh.h and trimesh.cpp

### DIFF
--- a/include/bg/trimesh.h
+++ b/include/bg/trimesh.h
@@ -84,8 +84,9 @@ BG_EXPORT extern int bg_trimesh_manifold_closed(int vcnt, int fcnt, fastf_t *v, 
 BG_EXPORT extern int bg_trimesh_oriented(int vcnt, int fcnt, fastf_t *v, int *f);
 
 /**
- * Check if a mesh is topologically solid. True if the mesh is closed,
- * manifold, and oriented.
+ * Check if a mesh is topologically solid. Returns TRUE if the mesh is
+ * NOT SOLID and FALSE if the mesh is SOLID. A FALSE outcome indicates
+ * the mesh satisfies all three criteria:  Closed, Manifold, Oriented
  */
 BG_EXPORT extern int bg_trimesh_solid(int vcnt, int fcnt, fastf_t *v, int *f, int **bedges);
 

--- a/src/libbg/trimesh.cpp
+++ b/src/libbg/trimesh.cpp
@@ -381,7 +381,8 @@ bg_trimesh_solid(int vcnt, int fcnt, fastf_t *v, int *f, int **bedges)
 	bedge_cnt = bg_trimesh_solid2(vcnt, fcnt, v, f, NULL);
     }
 
-    return bedge_cnt;
+    /* returns true when not solid */
+    return (bedge_cnt > 0) ? 1 : 0;
 }
 
 int


### PR DESCRIPTION
Clarified role of function bg_trimesh_solid:
Check if a mesh is topologically solid. Returns TRUE if the mesh is
NOT SOLID and FALSE if the mesh is SOLID. A FALSE outcome indicates
the mesh satisfies all three criteria:  Closed, Manifold, Oriented