### PR TITLE
rt_regionfix polite error reporting

### DIFF
--- a/src/librt/regionfix.c
+++ b/src/librt/regionfix.c
@@ -71,7 +71,7 @@ rt_regionfix(struct rt_i *rtip)
 
     fp = fopen(file, "rb");
     if (fp == NULL) {
-	if (rtip->rti_region_fix_file) bu_log("%s: unable to open REGEXP file\n", file);
+	if (rtip->rti_region_fix_file) bu_log("unable to open REGEXP file: %s\n", file);
 	bu_vls_free(&name);
 	return;
     }

--- a/src/librt/regionfix.c
+++ b/src/librt/regionfix.c
@@ -71,7 +71,7 @@ rt_regionfix(struct rt_i *rtip)
 
     fp = fopen(file, "rb");
     if (fp == NULL) {
-	if (rtip->rti_region_fix_file) perror(file);
+	if (rtip->rti_region_fix_file) bu_log("%s: unable to open REGEXP file\n", file);
 	bu_vls_free(&name);
 	return;
     }


### PR DESCRIPTION
rt_regionfix was treating the inability to open a region fix file as an error worthy of direct printing to stderr. However this condition didn't invalidate the rt_i and the calling function (rt_prep_parallel) remained blissfully unaware.

After this fix rt_regionfix calls bu_log instead of perror. This permits error reporting on the user's terms: if the log is to be saved to file, then so be it; if the log is to be ignored, then so be it; etc.

fixes #101 