### PR TITLE
k-g.cpp converter patch 

### DIFF
--- a/src/conv/k-g.cpp
+++ b/src/conv/k-g.cpp
@@ -613,7 +613,7 @@ main(int argc, char **argv)
 	bu_exit(1, "Error: file %s already exists.\n", argv[1]);
     }
 
-    std::ifstream infile(argv[0]);
+    std::ifstream infile(argv[0], std::ios::binary);
     if (!infile.is_open()) {
 	bu_exit(1, "Error: unable to open %s for reading.\n", argv[0]);
     }


### PR DESCRIPTION
the k-g converter was producing and empty data base, the error is due to the function ifsteam::tellg() returning a wrong position, the fix is to specify the input file as binary when opening the ifstream. 