### PR TITLE
Update README.Linux

### DIFF
--- a/doc/README.Linux
+++ b/doc/README.Linux
@@ -67,7 +67,7 @@ Following the build instructions in the INSTALL file.  You will need:
 gcc (6+, e.g. 6.0.3)
 g++ (6+, e.g. 6.0.3)
 make (e.g. gnu make 3.8.0)
-cmake (3.0.2 or newer)
+cmake (3.25.0 or newer)
 
 All three of those have implicit dependencies on other packages.
 


### PR DESCRIPTION
Cmake requirement for ubuntu/debian changed to 3.25.0 as the build has a new signature style which fails if build with a cmake version lower than 3.25.0