### PR TITLE
Added Section_SeatBelt and Element_SeatBelt in k_parser.cpp -  Patch submission

### DIFF
--- a/src/conv/k-g/k_parser.cpp
+++ b/src/conv/k-g/k_parser.cpp
@@ -55,12 +55,12 @@ enum class KState {
     //Element_Mass_Matrix,
     //Element_Mass_Part,
     //Element_Plotel,
-    //Element_Seatbealt,
-    //Element_Seatbealt_Accelerometer,
-    //Element_Seatbealt_Pretensioner,
-    //Element_Seatbealt_Retractor,
-    //Element_Seatbealt_Sensor,
-    //Element_Seatbealt_Slipring,
+    Element_Seatbelt,
+    //Element_Seatbelt_Accelerometer,
+    //Element_Seatbelt_Pretensioner,
+    //Element_Seatbelt_Retractor,
+    //Element_Seatbelt_Sensor,
+    //Element_Seatbelt_Slipring,
     Element_Shell,
     //Element_Shell_Nurbs_Patch,
     //Element_Shell_Source_Sink,
@@ -80,7 +80,7 @@ enum class KState {
     //Section_Fpd,
     //Section_Point_Source,
     //Section_Point_source_Mixture,
-    //Section_Seatbelt,
+    Section_Seatbelt,
     Section_Shell,
     Section_Solid,
     //Section_Solid_Peri,
@@ -631,32 +631,32 @@ bool parse_k
 			    }
 			    else if ((command.size() > 1) && (command[1] == "SEATBELT")) {
 				if ((command.size() > 2) && (command[2] == "ACCELEROMETER")) {
-				    //state = KState::Element_Seatbealt_Accelerometer;
+				    //state = KState::Element_Seatbelt_Accelerometer;
 
 				    optionsContainer.insert(optionsContainer.end(), command.begin() + 3, command.end());
 				}
 				else if ((command.size() > 2) && (command[2] == "PRETENSIONER")) {
-				    //state = KState::Element_Seatbealt_Pretensioner;
+				    //state = KState::Element_Seatbelt_Pretensioner;
 
 				    optionsContainer.insert(optionsContainer.end(), command.begin() + 3, command.end());
 				}
 				else if ((command.size() > 2) && (command[2] == "RETRACTOR")) {
-				    //state = KState::Element_Seatbealt_Retractor;
+				    //state = KState::Element_Seatbelt_Retractor;
 
 				    optionsContainer.insert(optionsContainer.end(), command.begin() + 3, command.end());
 				}
 				else if ((command.size() > 2) && (command[2] == "SENSOR")) {
-				    //state = KState::Element_Seatbealt_Sensor;
+				    //state = KState::Element_Seatbelt_Sensor;
 
 				    optionsContainer.insert(optionsContainer.end(), command.begin() + 3, command.end());
 				}
 				else if ((command.size() > 2) && (command[2] == "SLIPRING")) {
-				    //state = KState::Element_Seatbealt_Slipring;
+				    //state = KState::Element_Seatbelt_Slipring;
 
 				    optionsContainer.insert(optionsContainer.end(), command.begin() + 3, command.end());
 				}
 				else {
-				    //state = KState::Element_Seatbealt;
+				    state = KState::Element_Seatbelt;
 
 				    optionsContainer.insert(optionsContainer.end(), command.begin() + 2, command.end());
 				}
@@ -794,6 +794,18 @@ bool parse_k
 					std::cout << "Unexpected command " << tokens[0] << " in k-file " << fileName << std::endl;
 				}
 			    }
+				else if (command[1] == "SEATBELT") {
+				state = KState::Section_Seatbelt;
+				sectionTitle = "";
+				sectionId = -1;
+
+				if (command.size() == 3) {
+					if (command[2] == "TITLE")
+						sectionLinesRead = 0;
+					else
+						std::cout << "Unexpected command " << tokens[0] << " in k-file " << fileName << "\n";
+				}
+				}
 			    else
 				std::cout << "Unexpected command " << tokens[0] << " in k-file " << fileName << std::endl;
 			}
@@ -1125,6 +1137,35 @@ bool parse_k
 			++sectionLinesRead;
 			break;
 		    }
+
+			case KState::Section_Seatbelt: {
+				switch (sectionLinesRead) {
+				case 0: {
+					sectionTitle = line;
+					break;
+				}
+				case 1: {
+					if (tokens.size() < 3) {
+						std::cout << "Too short SECTION_SeatBelt in k-file " << fileName << "\n";
+						break;
+					}
+
+					sectionId = stoi(tokens[0]);
+
+					if (sectionId < 0) {
+						std::cout << "Bad SECTION in k-file " << fileName << "\n";
+						break;
+					}
+
+					data.sections[sectionId].title = sectionTitle;
+					data.sections[sectionId].area = stod(tokens[1]);
+					data.sections[sectionId].thickness1 = stod(tokens[2]);
+					break;
+				}
+				}
+				++sectionLinesRead;
+				break;
+			}
 
 		    case KState::Section_Shell: {
 			switch (sectionLinesRead) {
@@ -1527,6 +1568,57 @@ bool parse_k
 			++elementLinesRead;
 			break;
 		    }
+
+			case KState::Element_Seatbelt: {
+				KElementSeatBelt seatBelt;
+				int eid = 1;
+				int pid = 1;
+
+
+				if (tokens.size() < 6) {
+					std::cout << "Too short ELEMENT_SEAT_BELT in k-file" << fileName << "\n";
+					break;
+				}
+
+				eid = stoi(tokens[0]);
+				pid = stoi(tokens[1]);
+
+				/*int i_end = 0;
+
+				if (tokens.size() > 6) {
+					i_end = 7;
+				}
+				else {
+					i_end = 5;
+				}
+
+				for (int i_n = 0; i_n <= i_end; ++i_n) {
+					if (i_n == 4) {
+						seatBelt.retractorId = stoi(tokens[i_n]);
+					}
+					else if (i_n == 5) {
+						seatBelt.initialSlackLength = stof(tokens[i_n]);
+					}
+					else {
+						seatBelt.nodes.push_back(stoi(tokens[i_n]));
+					}
+				}*/
+				seatBelt.nodes.push_back(stoi(tokens[2]));
+				seatBelt.nodes.push_back(stoi(tokens[3]));
+
+				seatBelt.retractorId = stoi(tokens[4]);
+				seatBelt.initialSlackLength = stof(tokens[5]);
+
+				if (tokens.size() > 6) {
+					seatBelt.nodes.push_back(stoi(tokens[6]));
+					seatBelt.nodes.push_back(stoi(tokens[7]));
+				}
+
+				data.elementSeatBelt[eid] = seatBelt;
+				data.parts[pid].elements.insert(eid);
+				break;
+			}
+
 		}
 	    }
 

--- a/src/conv/k-g/k_parser.h
+++ b/src/conv/k-g/k_parser.h
@@ -80,6 +80,11 @@ struct KElementBearing {
     float       totalRadianceClearenceBetweenBallAndRaces;
 };
 
+struct KElementSeatBelt {
+    std::vector<int> nodes;
+    int              retractorId;
+    float            initialSlackLength;
+};
 
 struct KPart {
     std::string                        title;
@@ -95,6 +100,7 @@ struct KSection {
     double      thickness2;
     double      thickness3;
     double      thickness4;
+    double      area;
 };
 
 
@@ -117,6 +123,7 @@ struct KData {
     std::map<int, KElementPulley>     elementsPulley;
     std::map<int, KElementBeamSource> elementsBeamSource;
     std::map<int, KElementBearing>    elementBearing;
+    std::map<int, KElementSeatBelt>   elementSeatBelt;
     std::map<int, KPart>              parts;
     std::map<int, KSection>           sections;
     std::map<int, KSectionBeam>       sectionsBeam;


### PR DESCRIPTION
First development of Section_Seatbelt and Element_Seatbelt in k_parser.cpp 
The k_parser.h has been updated accordingly

k_parser.cpp includes an alternative approach (commented) for storing card information in elementSeatBelt data. Any feedback on the preferred method is highly appreciate it.

Patch proposal includes small typo corrections (only related to Seat Belt).

