### PR TITLE
Fix Unsafe Floating-Point Comparison in bn_nextafterf_up and bn_nexta…

### DIFF
--- a/src/libbn/ulp.c
+++ b/src/libbn/ulp.c
@@ -245,7 +245,7 @@ bn_nextafter_up(double val)
 	return val;
 
     /* unify both +0 and -0 into +0’s next subnormal */
-    if (!val) {
+    if (fabs(val) < DBL_EPSILON) {
         bits.u = 1ULL; /* raw 0x0000…001 */
         return bits.d;
     }
@@ -265,7 +265,7 @@ bn_nextafter_dn(double val)
 	return val;
 
     /* unify both +0 and -0 into -0’s next subnormal */
-    if (!val) {
+    if (fabs(val) < DBL_EPSILON) {
         /* raw, largest negative subnormal */
         bits.i = (int64_t)0x8000000000000001ULL;
         return bits.d;
@@ -285,7 +285,7 @@ bn_nextafterf_up(float val)
     if (isnan(val) || isinf(val))
 	return val;
 
-    if (!val) {
+    if (fabs(val) < FLT_EPSILON) {
         bits.u = 1U; /* raw 0x00000001 */
         return bits.f;
     }
@@ -305,7 +305,7 @@ bn_nextafterf_dn(float val)
 	return val;
 
     /* unify both +0 and -0 into -0’s next subnormal */
-    if (!val) {
+    if (fabs(val) < FLT_EPSILON) {
         /* raw, largest negative subnormal */
         bits.u = 0x80000001U;
         return bits.f;
@@ -327,7 +327,7 @@ bn_ulp(double val)
 
     bits.d = val;
     bits.u++; /* next "bigger" val */
-    if (!val || val > 0.0) {
+    if (fabs(val) < DBL_EPSILON || val > 0.0) {
 	return bits.d - val;
     }
     return -bits.d + val;
@@ -344,7 +344,7 @@ bn_ulpf(float val)
 
     bits.f = val;
     bits.i++; /* next "bigger" val */
-    if (!val || val > 0.0f) {
+    if (fabs(val) < FLT_EPSILON || val > 0.0f) {
 	return bits.f - val;
     }
     return -bits.f + val;


### PR DESCRIPTION
This PR addresses an issue where the code in `libbn/ulp.c` used unsafe comparisons for floating-point values, specifically in the `bn_nextafterf_up` and `bn_nextafterf_dn` functions. The use of `!val` to check for zero is problematic, as it assumes that `val` is exactly zero, which can cause inaccuracies due to floating-point precision issues.



Fixes #184 

- Replaced `!val` checks with `fabs(val) < FLT_EPSILON` in both the `bn_nextafterf_up` and `bn_nextafterf_dn` functions. This ensures that comparisons for near-zero floating-point values are done safely using a tolerance (`FLT_EPSILON`).
- This change prevents the unsafe comparison and ensures compatibility with floating-point arithmetic, addressing both the precision issues and the compiler warning.

![Screenshot from 2025-04-26 05-23-32](https://github.com/user-attachments/assets/15242960-db8f-430d-a7ea-87fdcdb3eb03)







