### PR TITLE
Remove documentation error in clang

### DIFF
--- a/include/bg/plane.h
+++ b/include/bg/plane.h
@@ -814,7 +814,7 @@ BG_EXPORT extern int bg_isect_2lines(fastf_t *t,
  * @return 2	Intersection at vertex B
  * @return 3	Intersection between A and B
  *
- * @par Implicit Returns -
+ * Implicit Returns -
  *
  * t When explicit return >= 0, t is the parameter that describes the
  * intersection of the line and the line segment.  The actual

--- a/include/bu/cv.h
+++ b/include/bu/cv.h
@@ -230,7 +230,7 @@ BU_EXPORT extern size_t bu_cv_itemlen(int cookie);
  * steps are done.  The more difficult cases are when only a subset of
  * steps need to be done.
  *
- * @par Method:
+ * Method:
  * @code
  *	HOSTDBL defined as true or false
  *	if ! hostother then


### PR DESCRIPTION
Remove error in clang.
```
/Users/lee/src/brlcad/include/bu/cv.h:233:15: error: empty paragraph passed to '@par' command [-Werror,-Wdocumentation]
  233 |  * @par Method:
      |    ~~~~~~~~~~~^
  234 |  * @code
      |  ~
```