### PR TITLE
Fix stack buffer overflow in nastran-g PBAR/PSHELL name generation

### DIFF
--- a/src/conv/nastran-g.c
+++ b/src/conv/nastran-g.c
@@ -221,13 +221,13 @@ do_silly_nastran_shortcuts(void)
 
 		a = atof(prev_rec[field_no]);
 		b = atof(&curr_rec[field_no][i]);
-		sprintf(curr_rec[field_no], "%-#*E", FIELD_LENGTH-6, a+b);
+		snprintf(curr_rec[field_no], FIELD_LENGTH, "%-#*E", FIELD_LENGTH-6, a+b);
 	    } else {
 		int a, b;
 
 		a = atoi(prev_rec[field_no]);
 		b = atoi(&curr_rec[field_no][i]);
-		sprintf(curr_rec[field_no], "%d", a+b);
+		snprintf(curr_rec[field_no], FIELD_LENGTH, "%d", a+b);
 	    }
 	}
     }
@@ -1057,7 +1057,7 @@ get_cbar(void)
     fastf_t radius;
     vect_t height;
     struct pbar *pb;
-    char cbar_name[NAMESIZE+1];
+    char cbar_name[32];
 
     eid = atoi(curr_rec[1]);
 
@@ -1094,7 +1094,7 @@ get_cbar(void)
 
     VSUB2(height, pt2, pt1);
 
-    sprintf(cbar_name, "cbar.%d", eid);
+    snprintf(cbar_name, sizeof(cbar_name), "cbar.%d", eid);
     mk_rcc(fpout, cbar_name, pt1, height, radius);
 
     mk_addmember(cbar_name, &pb->head.l, NULL, WMOP_UNION);
@@ -1328,7 +1328,7 @@ main(int argc, char **argv)
     BU_LIST_INIT(&head.l);
     for (BU_LIST_FOR(psh, pshell, &pshell_head.l)) {
 	struct model *m;
-	char name[NAMESIZE+1];
+	char name[32];
 
 	if (!psh->s)
 	    continue;
@@ -1340,7 +1340,7 @@ main(int argc, char **argv)
 	    nmg_model_face_fuse(m, vlfree, &tol);
 	    nmg_hollow_shell(psh->s, psh->thick*conv[units], 1, vlfree, &tol);
 	}
-	sprintf(name, "pshell.%d", psh->pid);
+	snprintf(name, sizeof(name), "pshell.%d", psh->pid);
 	if (polysolids)
 	    mk_bot_from_nmg(fpout, name, psh->s);
 	else
@@ -1355,12 +1355,12 @@ main(int argc, char **argv)
 
     BU_LIST_INIT(&head.l);
     for (BU_LIST_FOR(pbp, pbar, &pbar_head.l)) {
-	char name[NAMESIZE+1];
+	char name[32];
 
 	if (BU_LIST_IS_EMPTY(&pbp->head.l))
 	    continue;
 
-	sprintf(name, "pbar_group.%d", pbp->pid);
+	snprintf(name, sizeof(name), "pbar_group.%d", pbp->pid);
 	mk_lfcomb(fpout, name, &pbp->head, 0);
 
 	mk_addmember(name, &head.l, NULL, WMOP_UNION);


### PR DESCRIPTION
### Description
PR fixes the stack buffer overflow in nastran-g.c when PBAR/PSHELL PIDs are large.
Uses snprintf and increases buffer sizes.


Fixes #211

