### PR TITLE
librt/nmg: guard pl_ray() debug plotting behind NMG_DEBUG_PLOTEM

### DIFF
--- a/src/librt/primitives/nmg/nmg.c
+++ b/src/librt/primitives/nmg/nmg.c
@@ -375,7 +375,9 @@ unresolved(struct hitmiss *next_hit, struct bu_ptbl *a_tbl, struct bu_ptbl *next
 	bu_log("\t%ld %s\n", **l_p, bu_identify_magic(**l_p));
 
     bu_log("<---Unable to fix state transition\n");
-    pl_ray(rd);
+    if (nmg_debug & NMG_DEBUG_PLOTEM) {
+        pl_ray(rd);
+    }
     bu_log("Primitive: %s, pixel=%d %d,  lvl=%d %s\n",
 	   rd->stp->st_dp->d_namep,
 	   rd->ap->a_x, rd->ap->a_y, rd->ap->a_level,


### PR DESCRIPTION
pl_ray() currently writes .plot3 files unconditionally when triggered from unresolved(), which can result in unexpected file output during NMG raytracing.

This change guards the pl_ray() call behind the existing NMG_DEBUG_PLOTEM flag (“make plots in debugged routines”), ensuring plot files are only generated when explicitly requested via NMG debug flags.

This preserves existing debugging functionality while avoiding default disk writes.
