### PR TITLE
Fix font persistence by syncing Tk named fonts to mged_default before saving .mgedrc

### DIFF
--- a/src/tclscripts/mged/font.tcl
+++ b/src/tclscripts/mged/font.tcl
@@ -207,10 +207,14 @@ proc mged_font_persistence_test {{id ""}} {
         array set default_map $mged_default($fname)
 
         set mismatch 0
-        foreach key [array names actual_map] {
-            if {![info exists default_map($key)] || $default_map($key) ne $actual_map($key)} {
-                set mismatch 1
-                break
+        if {[array size actual_map] != [array size default_map]} {
+            set mismatch 1
+        } else {
+            foreach key [array names actual_map] {
+                if {![info exists default_map($key)] || $default_map($key) ne $actual_map($key)} {
+                    set mismatch 1
+                    break
+                }
             }
         }
 
@@ -243,10 +247,14 @@ proc mged_font_persistence_test {{id ""}} {
         array set default_map $mged_default($fname)
 
         set mismatch 0
-        foreach key [array names actual_map] {
-            if {![info exists default_map($key)] || $default_map($key) ne $actual_map($key)} {
-                set mismatch 1
-                break
+        if {[array size actual_map] != [array size default_map]} {
+            set mismatch 1
+        } else {
+            foreach key [array names actual_map] {
+                if {![info exists default_map($key)] || $default_map($key) ne $actual_map($key)} {
+                    set mismatch 1
+                    break
+                }
             }
         }
 

--- a/src/tclscripts/mged/font.tcl
+++ b/src/tclscripts/mged/font.tcl
@@ -183,14 +183,18 @@ proc mged_font_persistence_test {{id ""}} {
     }
 
     if {$id != ""} {
-        lappend font_names fs_all_font($id)
+        lappend font_names all_font
     }
 
     set has_fail 0
 
     foreach fname $font_names {
-        if {[catch {set actual [font actual $fname]}]} {
-            puts "FAIL: $fname (named font missing)"
+        set live_name $fname
+        if {$fname eq "all_font" && $id != ""} {
+            set live_name fs_all_font($id)
+        }
+        if {[catch {set actual [font actual $live_name]}]} {
+            puts "FAIL: $live_name (named font missing)"
             set has_fail 1
             continue
         }
@@ -219,18 +223,22 @@ proc mged_font_persistence_test {{id ""}} {
         }
 
         if {$mismatch} {
-            puts "FAIL: $fname (before sync)"
+            puts "FAIL: $live_name (before sync)"
             set has_fail 1
         } else {
-            puts "PASS: $fname (before sync)"
+            puts "PASS: $live_name (before sync)"
         }
     }
 
     mged_font_sync_to_defaults $id
 
     foreach fname $font_names {
-        if {[catch {set actual [font actual $fname]}]} {
-            puts "FAIL: $fname (named font missing after sync)"
+        set live_name $fname
+        if {$fname eq "all_font" && $id != ""} {
+            set live_name fs_all_font($id)
+        }
+        if {[catch {set actual [font actual $live_name]}]} {
+            puts "FAIL: $live_name (named font missing after sync)"
             set has_fail 1
             continue
         }
@@ -259,10 +267,10 @@ proc mged_font_persistence_test {{id ""}} {
         }
 
         if {$mismatch} {
-            puts "FAIL: $fname (after sync)"
+            puts "FAIL: $live_name (after sync)"
             set has_fail 1
         } else {
-            puts "PASS: $fname (after sync)"
+            puts "PASS: $live_name (after sync)"
         }
     }
 

--- a/src/tclscripts/mged/mgedrc.tcl
+++ b/src/tclscripts/mged/mgedrc.tcl
@@ -78,7 +78,7 @@ proc update_mgedrc {} {
 	    puts -nonewline $fd [string range $data 0 $index]
 	}
 
-	if {[info procs mged_font_sync_to_defaults] != ""} {
+	if [info procs mged_font_sync_to_defaults] != "" {
 	    mged_font_sync_to_defaults
 	}
 
@@ -97,7 +97,7 @@ proc update_mgedrc {} {
 	    error $msg
 	}
 
-	if {[info procs mged_font_sync_to_defaults] != ""} {
+	if [info procs mged_font_sync_to_defaults] != "" {
 	    mged_font_sync_to_defaults
 	}
 

--- a/src/tclscripts/mged/mgedrc.tcl
+++ b/src/tclscripts/mged/mgedrc.tcl
@@ -78,6 +78,10 @@ proc update_mgedrc {} {
 	    puts -nonewline $fd [string range $data 0 $index]
 	}
 
+	if {[info procs mged_font_sync_to_defaults] != ""} {
+	    mged_font_sync_to_defaults
+	}
+
 	if [catch {dump_mged_state $fd} msg] {
 	    close $fd
 	    file copy -force $tmpmgedrc $mgedrc
@@ -91,6 +95,10 @@ proc update_mgedrc {} {
 	# Create a new .mgedrc
 	if [catch {set fd [open $mgedrc w]} msg] {
 	    error $msg
+	}
+
+	if {[info procs mged_font_sync_to_defaults] != ""} {
+	    mged_font_sync_to_defaults
 	}
 
 	if [catch {dump_mged_state $fd} msg] {


### PR DESCRIPTION
This fixes the issue where font changes made in the MGED GUI weren’t being saved to .mgedrc. The problem was that the GUI updates the live Tk named fonts, but .mgedrc is written using the mged_default variables. Since those weren’t being synced, the saved config didn’t reflect the updated fonts.
To fix this, I added a small sync function called mged_font_sync_to_defaults that copies the current font settings from the Tk named fonts into the mged_default variables. The sync uses font actual so it captures the fully resolved font values 
I hooked this into the font “Apply” actions and also before .mgedrc is written in update_mgedrc, so now the saved file matches whatever the user sets in the GUI.
With this change, font settings should persist correctly after saving and restarting.