### PR TITLE
Fix inmemory database write

### DIFF
--- a/src/librt/db5_alloc.c
+++ b/src/librt/db5_alloc.c
@@ -117,7 +117,11 @@ db5_realloc(struct db_i *dbip, struct directory *dp, struct bu_external *ep)
     baseaddr = dp->d_addr;
     baselen = dp->d_len;
 
-    if (dp->d_flags & RT_DIR_INMEM) {
+    if ((dp->d_flags & RT_DIR_INMEM) || !dbip->dbi_fp) {
+	if (!(dp->d_flags & RT_DIR_INMEM)) {
+	    dp->d_flags |= RT_DIR_INMEM;
+	    dp->d_un.ptr = NULL;
+	}
 	if (dp->d_un.ptr) {
 	    if (RT_G_DEBUG&RT_DEBUG_DB)
 		bu_log("db5_realloc(%s) bu_realloc()ing memory resident object\n", dp->d_namep);

--- a/src/librt/db5_scan.c
+++ b/src/librt/db5_scan.c
@@ -382,7 +382,14 @@ db_dirbuild(struct db_i *dbip)
     RT_CK_DBI(dbip);
 
     if (!dbip->dbi_fp) {
-	return -1;
+	if (dbip->dbi_inmem) {
+	    return db_dirbuild_inmem(dbip, dbip->dbi_inmem, dbip->dbi_eof);
+	}
+	/* Fresh in-memory database, nothing to build */
+	if (dbip->dbi_eof == RT_DIR_PHONY_ADDR) {
+	    dbip->dbi_eof = 0;
+	}
+	return 0;
     }
 
     /* First, determine what version database this is */

--- a/src/librt/db_lookup.c
+++ b/src/librt/db_lookup.c
@@ -288,10 +288,13 @@ db_diradd(struct db_i *dbip, const char *name, b_off_t laddr, size_t len, int fl
     RT_DIR_SET_NAMEP(dp, bu_vls_addr(&local));	/* sets d_namep */
     dp->d_addr = laddr;
 
-    /* TODO: investigate removing exclusion of INMEM flag, added by
-     * mike in c13285 when in-mem support was originally added
-     */
-    dp->d_flags = flags & ~(RT_DIR_INMEM);
+    /* If there's no database file, then this MUST be an in-memory object. */
+    if (dbip->dbi_fp == NULL) {
+	dp->d_flags = flags | RT_DIR_INMEM;
+    } else {
+	dp->d_flags = flags & ~(RT_DIR_INMEM);
+    }
+
     dp->d_len = len;
     dp->d_forw = *headp;
     BU_LIST_INIT(&dp->d_use_hd);

--- a/src/tclscripts/mged/font.tcl
+++ b/src/tclscripts/mged/font.tcl
@@ -207,10 +207,14 @@ proc mged_font_persistence_test {{id ""}} {
         array set default_map $mged_default($fname)
 
         set mismatch 0
-        foreach key [array names actual_map] {
-            if {![info exists default_map($key)] || $default_map($key) ne $actual_map($key)} {
-                set mismatch 1
-                break
+        if {[array size actual_map] != [array size default_map]} {
+            set mismatch 1
+        } else {
+            foreach key [array names actual_map] {
+                if {![info exists default_map($key)] || $default_map($key) ne $actual_map($key)} {
+                    set mismatch 1
+                    break
+                }
             }
         }
 
@@ -243,10 +247,14 @@ proc mged_font_persistence_test {{id ""}} {
         array set default_map $mged_default($fname)
 
         set mismatch 0
-        foreach key [array names actual_map] {
-            if {![info exists default_map($key)] || $default_map($key) ne $actual_map($key)} {
-                set mismatch 1
-                break
+        if {[array size actual_map] != [array size default_map]} {
+            set mismatch 1
+        } else {
+            foreach key [array names actual_map] {
+                if {![info exists default_map($key)] || $default_map($key) ne $actual_map($key)} {
+                    set mismatch 1
+                    break
+                }
             }
         }
 

--- a/src/tclscripts/mged/font.tcl
+++ b/src/tclscripts/mged/font.tcl
@@ -183,14 +183,18 @@ proc mged_font_persistence_test {{id ""}} {
     }
 
     if {$id != ""} {
-        lappend font_names fs_all_font($id)
+        lappend font_names all_font
     }
 
     set has_fail 0
 
     foreach fname $font_names {
-        if {[catch {set actual [font actual $fname]}]} {
-            puts "FAIL: $fname (named font missing)"
+        set live_name $fname
+        if {$fname eq "all_font" && $id != ""} {
+            set live_name fs_all_font($id)
+        }
+        if {[catch {set actual [font actual $live_name]}]} {
+            puts "FAIL: $live_name (named font missing)"
             set has_fail 1
             continue
         }
@@ -219,18 +223,22 @@ proc mged_font_persistence_test {{id ""}} {
         }
 
         if {$mismatch} {
-            puts "FAIL: $fname (before sync)"
+            puts "FAIL: $live_name (before sync)"
             set has_fail 1
         } else {
-            puts "PASS: $fname (before sync)"
+            puts "PASS: $live_name (before sync)"
         }
     }
 
     mged_font_sync_to_defaults $id
 
     foreach fname $font_names {
-        if {[catch {set actual [font actual $fname]}]} {
-            puts "FAIL: $fname (named font missing after sync)"
+        set live_name $fname
+        if {$fname eq "all_font" && $id != ""} {
+            set live_name fs_all_font($id)
+        }
+        if {[catch {set actual [font actual $live_name]}]} {
+            puts "FAIL: $live_name (named font missing after sync)"
             set has_fail 1
             continue
         }
@@ -259,10 +267,10 @@ proc mged_font_persistence_test {{id ""}} {
         }
 
         if {$mismatch} {
-            puts "FAIL: $fname (after sync)"
+            puts "FAIL: $live_name (after sync)"
             set has_fail 1
         } else {
-            puts "PASS: $fname (after sync)"
+            puts "PASS: $live_name (after sync)"
         }
     }
 

--- a/src/tclscripts/mged/mgedrc.tcl
+++ b/src/tclscripts/mged/mgedrc.tcl
@@ -78,7 +78,7 @@ proc update_mgedrc {} {
 	    puts -nonewline $fd [string range $data 0 $index]
 	}
 
-	if {[info procs mged_font_sync_to_defaults] != ""} {
+	if [info procs mged_font_sync_to_defaults] != "" {
 	    mged_font_sync_to_defaults
 	}
 
@@ -97,7 +97,7 @@ proc update_mgedrc {} {
 	    error $msg
 	}
 
-	if {[info procs mged_font_sync_to_defaults] != ""} {
+	if [info procs mged_font_sync_to_defaults] != "" {
 	    mged_font_sync_to_defaults
 	}
 

--- a/src/tclscripts/mged/mgedrc.tcl
+++ b/src/tclscripts/mged/mgedrc.tcl
@@ -78,6 +78,10 @@ proc update_mgedrc {} {
 	    puts -nonewline $fd [string range $data 0 $index]
 	}
 
+	if {[info procs mged_font_sync_to_defaults] != ""} {
+	    mged_font_sync_to_defaults
+	}
+
 	if [catch {dump_mged_state $fd} msg] {
 	    close $fd
 	    file copy -force $tmpmgedrc $mgedrc
@@ -91,6 +95,10 @@ proc update_mgedrc {} {
 	# Create a new .mgedrc
 	if [catch {set fd [open $mgedrc w]} msg] {
 	    error $msg
+	}
+
+	if {[info procs mged_font_sync_to_defaults] != ""} {
+	    mged_font_sync_to_defaults
 	}
 
 	if [catch {dump_mged_state $fd} msg] {


### PR DESCRIPTION
#161 
This PR fixes a write-path failure in in-memory databases in BRL-CAD that occurred when rt_db_put_internal() triggered db5_realloc(), which then called db_dirbuild() and failed because it assumed a file-backed database and returned an error when dbi_fp == NULL. I updated db_dirbuild() to properly handle in-memory databases by delegating to db_dirbuild_inmem() or initializing a fresh empty state by setting dbi_eof = 0, adjusted db5_realloc() to safely allocate memory when no file pointer exists instead of attempting disk-based allocation, and corrected db_diradd() to preserve the RT_DIR_INMEM flag for memory-only databases. These changes resolve the initialization deadlock while maintaining full backward compatibility for file-backed and memory-mapped databases.