### PR TITLE
gist: replace hardcoded render constants with named defaults

### DIFF
--- a/src/gtools/gist/PerspectiveGatherer.cpp
+++ b/src/gtools/gist/PerspectiveGatherer.cpp
@@ -20,6 +20,12 @@
 
 #include "PerspectiveGatherer.h"
 
+/* Default rendering parameters.
+ * These will be made configurable via a quality option in a future change.
+ */
+static const char *GIST_DEFAULT_RENDER_SIZE = "1024";
+static const char *GIST_DEFAULT_AMB_SAMPLES_CMD = "set ambSamples=8";
+
 std::map<char, FaceDetails>
 getFaceDetails()
 {
@@ -90,7 +96,7 @@ renderPerspective(RenderingFace face, Options& opt, std::string component, std::
     // reset the av to their needs
     const char* av[22] = { NULL,                    // [00]: cmd
                            "-s",                    // [01]
-                           "1024",                  // [02]
+                           GIST_DEFAULT_RENDER_SIZE, // [02]
                            "-W",                    // [03]
                            "-R",                    // [04]
                            "-a",                    // [05]
@@ -181,7 +187,7 @@ renderPerspective(RenderingFace face, Options& opt, std::string component, std::
             outputname += "_detailed.png";
 
             av[0] = cmd.c_str();
-            av[1] = "-s"; av[2] = "1024";
+            av[1] = "-s"; av[2] = GIST_DEFAULT_RENDER_SIZE;
             av[3] = "-W";
             av[4] = "-R";
             av[5] = "-a";  av[6] = "45";
@@ -189,7 +195,7 @@ renderPerspective(RenderingFace face, Options& opt, std::string component, std::
             av[9] = "-C";  av[10] = "255/255/255";
             av[13] = "-A"; av[14] = "1.2";
 	    /* FIXME: this needs to be user-configurable, at least low/high quality (along with image sizes)*/
-            av[15] = "-c"; av[16] = "set ambSamples=8";
+            av[15] = "-c"; av[16] = GIST_DEFAULT_AMB_SAMPLES_CMD;
             av[17] = "-o"; av[18] = outputname.c_str();
             av[19] = pathToInput.c_str();
             av[20] = component.c_str();
@@ -200,7 +206,7 @@ renderPerspective(RenderingFace face, Options& opt, std::string component, std::
             outputname += "_ghost.png";
 
             av[0] = cmd.c_str();
-            av[1] = "-s";  av[2] = "1024";
+            av[1] = "-s";  av[2] = GIST_DEFAULT_RENDER_SIZE;
             av[3] = "-a";  av[4] = "35";
             av[5] = "-e";  av[6] = "25";
             av[7] = "-i";  av[8] = pathToInput.c_str();


### PR DESCRIPTION
Replace hardcoded render size ("1024") and ambient occlusion samples ("set ambSamples=8") literals in PerspectiveGatherer.cpp with file-local static constants.

No behavioral change. This prepares for future quality configuration work.