### PR TITLE
Fix potential stack buffer overflows in nastran-g.c by using snprintf

### DIFF
--- a/src/conv/nastran-g.c
+++ b/src/conv/nastran-g.c
@@ -1340,7 +1340,11 @@ main(int argc, char **argv)
 	    nmg_model_face_fuse(m, vlfree, &tol);
 	    nmg_hollow_shell(psh->s, psh->thick*conv[units], 1, vlfree, &tol);
 	}
-	sprintf(name, "pshell.%d", psh->pid);
+	char name[32];
+	if (snprintf(name, sizeof(name), "pshell.%d", psh->pid) >= (int)sizeof(name)) {
+	    bu_log("Warning: pshell name truncated for pid %d, skipping.\n", psh->pid);
+	    continue;
+	}
 	if (polysolids)
 	    mk_bot_from_nmg(fpout, name, psh->s);
 	else
@@ -1355,12 +1359,15 @@ main(int argc, char **argv)
 
     BU_LIST_INIT(&head.l);
     for (BU_LIST_FOR(pbp, pbar, &pbar_head.l)) {
-	char name[NAMESIZE+1];
+	char name[32];
 
 	if (BU_LIST_IS_EMPTY(&pbp->head.l))
 	    continue;
 
-	sprintf(name, "pbar_group.%d", pbp->pid);
+	if (snprintf(name, sizeof(name), "pbar_group.%d", pbp->pid) >= (int)sizeof(name)) {
+	    bu_log("Warning: pbar_group name truncated for pid %d, skipping.\n", pbp->pid);
+	    continue;
+	}
 	mk_lfcomb(fpout, name, &pbp->head, 0);
 
 	mk_addmember(name, &head.l, NULL, WMOP_UNION);


### PR DESCRIPTION
This PR fixes a stack buffer overflow vulnerability in src/conv/nastran-g.c when processing large PBAR and PSHELL PID values.

Previously, the code used sprintf() to write formatted group names (e.g., pbar_group.%d and pshell.%d) into a fixed-size stack buffer defined as char name[NAMESIZE+1] (17 bytes). Since large PID values can produce longer strings, this could exceed the buffer size and cause a stack overflow, potentially leading to crashes or undefined behavior.

The fix replaces sprintf() with snprintf() to ensure bounded writes, increases the buffer size to safely accommodate typical PID lengths, and adds proper return-value checking to detect truncation. If formatting fails or truncation occurs, the code logs a warning using bu_log() and skips the affected entry.

These changes eliminate the overflow risk while preserving existing functionality and maintaining backward compatibility. #211 