### PR TITLE
Fix minor bugs and code quality issues in art/appleseed renderer

### DIFF
--- a/src/art/art.cpp
+++ b/src/art/art.cpp
@@ -167,7 +167,7 @@
 
 struct resource* resources;
 size_t samples = 25;
-size_t light_intensity = 200.0; // make ambient light match rt
+size_t light_intensity = 200; // make ambient light match rt
 //size_t light_intensity = 30.0;
 const char* global_title_file;
 asf::auto_release_ptr<asr::Project> project_ptr;
@@ -830,7 +830,7 @@ build_project(const char* file, const char* UNUSED(objects))
 		));
         camera = pinhole;
     } else {
-        // Create a orthographic camera with film dimensions
+        // Create an orthographic camera with film dimensions
         bu_vls_sprintf(&dimensions, "%f %f", 2.0, 2.0);
         asf::auto_release_ptr<asr::Camera> ortho(
 	    asr::OrthographicCameraFactory().create(
@@ -950,34 +950,34 @@ fb_setup() {
 extern "C" void
 view_setup(struct rt_i* UNUSED(rtip))
 {
-    bu_bomb("In view setup, Dont call me!");
+    bu_bomb("In view setup, Don't call me!");
 }
 
 
 extern "C" void
 view_2init(struct application* UNUSED(ap), char* UNUSED(framename))
 {
-    bu_bomb("In 2init, Dont call me!");
+    bu_bomb("In 2init, Don't call me!");
 }
 
 
 extern "C" void
 view_end(struct application* UNUSED(ap)) {
-    bu_bomb("In end, Dont call me!");
+    bu_bomb("In end, Don't call me!");
 }
 
 
 extern "C" void
 view_cleanup(struct rt_i* UNUSED(rtip))
 {
-    bu_bomb("in cleanup, Dont call me!");
+    bu_bomb("in cleanup, Don't call me!");
 }
 
 
 extern "C" void
 do_run(int UNUSED(a), int UNUSED(b))
 {
-    bu_bomb("in run, Dont call me!");
+    bu_bomb("in run, Don't call me!");
 }
 
 

--- a/src/art/brlcadplugin.cpp
+++ b/src/art/brlcadplugin.cpp
@@ -1,4 +1,4 @@
-/*                     A R T P L U G I N . C P P
+/*               B R L C A D P L U G I N . C P P
  * BRL-CAD
  *
  * Copyright (c) 2004-2025 United States Government as represented by
@@ -407,7 +407,7 @@ BrlcadObject::get_objects() const
     std::vector<std::string> objects;
     int count = get_object_count();
 
-    for (char i = 0; i < count; i++) {
+    for (int i = 0; i < count; i++) {
 	std::string obj_num = "object." + std::to_string(i + 1);
 	objects.push_back(m_params.get_path_required<std::string>(obj_num.c_str(), ""));
     }


### PR DESCRIPTION
## Summary
This PR addresses several minor bugs and code quality issues in BRL-CAD's Appleseed renderer (`src/art/`).

## Changes

### Bug Fixes
- **`brlcadplugin.cpp` - `char` loop variable overflow**: In `get_objects()`, the loop counter was declared as `char`, which is signed on most platforms and overflows silently for object counts > 127. Changed to `int` to match the `count` variable type.
- - **`art.cpp` - float-to-integer assignment**: `light_intensity` is declared as `size_t` but was initialized with `200.0` (a floating-point literal). Changed to `200` to avoid implicit truncation.
### Code Quality
- **`brlcadplugin.cpp` - incorrect header comment**: File header said `A R T P L U G I N . C P P` but the file is `brlcadplugin.cpp`. Corrected to `B R L C A D P L U G I N . C P P`.
- - **`art.cpp` - grammar fix**: Changed "a orthographic" to "an orthographic" in camera comment.
- - **`art.cpp` - error message typos**: Fixed missing apostrophe in 5 `bu_bomb()` error messages ("Dont" -> "Don't").
## Files Changed
- `src/art/art.cpp`
- - `src/art/brlcadplugin.cpp`