### PR TITLE
fix: corrections for analyze methods for `ehy`, `hyp` and `rhc`

### DIFF
--- a/src/libged/analyze/analyze.cpp
+++ b/src/libged/analyze/analyze.cpp
@@ -267,6 +267,10 @@ analyze_do_summary(struct ged *gedp, const struct rt_db_internal *ip)
 	    analyze_sketch(gedp, ip);
 	    break;
 
+	case ID_EHY:
+	    analyze_general(gedp, ip);
+	    break;
+
 	case ID_HYP:
 	    analyze_general(gedp, ip);
 	    break;

--- a/src/librt/primitives/ehy/ehy.c
+++ b/src/librt/primitives/ehy/ehy.c
@@ -2098,41 +2098,22 @@ rt_ehy_volume(fastf_t *volume, const struct rt_db_internal *ip)
 }
 
 
-/**
- * The centroid lies along ehy_H due to symmetry.
- * Initially the distance of the centroid from the apex is found. The
- * coordinates of the points at this distance along the unit vector
- * gives the centroid of the elliptical hyperboloid of two sheets.
- * Formula taken from: https://docs.google.com/file/d/0BydeQ6BPlVejRWt6NlJLVDl0d28/edit
- */
 void
 rt_ehy_centroid(point_t *cent, const struct rt_db_internal *ip)
 {
     struct rt_ehy_internal *eip;
-    fastf_t a, b, h, area, dist, pwr, dist_C;
-    vect_t h_vec, unit_vec;
-    point_t apex;
+    fastf_t c, h, c_z;
+
     RT_CK_DB_INTERNAL(ip);
-    eip =  (struct rt_ehy_internal *)ip->idb_ptr;
+    eip = (struct rt_ehy_internal *)ip->idb_ptr;
     RT_EHY_CK_MAGIC(eip);
 
-    a = eip->ehy_c;
+    c = eip->ehy_c;
     h = MAGNITUDE(eip->ehy_H);
-    b = (eip->ehy_r1 * a) / sqrt(h * h - 2 * a * h);
-
-    VMOVE(h_vec, eip->ehy_H);
-    VMOVE(apex, eip->ehy_V);
-    VSCALE(unit_vec, h_vec, (1 / h));
-
-    rt_ehy_surf_area( &area, ip);
-    pwr = pow(h * h + 2 * a * h, 3);
-    if(pwr < 0)
-	bu_log("invalid parameters.\n");
-    dist = ((2 * b) * sqrt(pwr)) / (3 * area * a);
-    dist_C = dist - a;
-
-    VJOIN1(*cent, apex, dist_C, unit_vec);
+    c_z = 0.75 * (2 * c + h) * (2 * c + h) / (3 * c + h);
+    VJOIN1(*cent, eip->ehy_V, (h + c - c_z) / h, eip->ehy_H);
 }
+
 
 int
 rt_ehy_labels(struct rt_point_labels *pl, int pl_max, const mat_t xform, const struct rt_db_internal *ip, const struct bn_tol *UNUSED(tol))

--- a/src/librt/primitives/ehy/ehy.c
+++ b/src/librt/primitives/ehy/ehy.c
@@ -2081,6 +2081,23 @@ rt_ehy_surf_area(fastf_t *area, const struct rt_db_internal *ip)
 }
 
 
+void
+rt_ehy_volume(fastf_t *volume, const struct rt_db_internal *ip)
+{
+    struct rt_ehy_internal *eip;
+    fastf_t c, h, scale;
+
+    RT_CK_DB_INTERNAL(ip);
+    eip = (struct rt_ehy_internal *)ip->idb_ptr;
+    RT_EHY_CK_MAGIC(eip);
+
+    c = eip->ehy_c;
+    h = MAGNITUDE(eip->ehy_H);
+    scale = c / sqrt(h * (2 * c + h));
+    *volume = M_PI * eip->ehy_r1 * scale * eip->ehy_r2 * scale * h * h / (3 * c * c) * (3 * c + h);
+}
+
+
 /**
  * The centroid lies along ehy_H due to symmetry.
  * Initially the distance of the centroid from the apex is found. The

--- a/src/librt/primitives/ehy/ehy.c
+++ b/src/librt/primitives/ehy/ehy.c
@@ -2063,21 +2063,36 @@ void
 rt_ehy_surf_area(fastf_t *area, const struct rt_db_internal *ip)
 {
     struct rt_ehy_internal *eip;
-    fastf_t a, b, h, integralArea, sqrt_rb;
+    fastf_t c, h, scale, a, b, a2, b2, c2, v0, mc, sv, st;
+    int n;
+
     RT_CK_DB_INTERNAL(ip);
     eip = (struct rt_ehy_internal *)ip->idb_ptr;
     RT_EHY_CK_MAGIC(eip);
 
-    a = eip->ehy_c;
+    c = eip->ehy_c;
     h = MAGNITUDE(eip->ehy_H);
-    b = (eip->ehy_r1 * a) / sqrt(h * (h - 2 * a));
+    scale = c / sqrt(h * (2 * c + h));
+    a = eip->ehy_r1 * scale;
+    b = eip->ehy_r2 * scale;
 
-    /** Formula taken from : https://docs.google.com/file/d/0BydeQ6BPlVejRWt6NlJLVDl0d28/edit
-     * Area can be calculated by subtracting integral of hyperbola from the area of the bounding rectangle
-     */
-    sqrt_rb = sqrt(eip->ehy_r1 * eip->ehy_r1 + b * b);
-    integralArea = (a / b) * ((eip->ehy_r1 * sqrt_rb) + ((b * b / 2) * (log(sqrt_rb + eip->ehy_r1) - log(sqrt_rb - eip->ehy_r1))));
-    *area = 2 * eip->ehy_r1 * (a + h) - integralArea;
+    v0 = acosh(1 + h / c);
+    a2 = a * a;
+    b2 = b * b;
+    c2 = c * c;
+
+    /* Monte Carlo integration */
+    for (mc = 0, n = 0; n < 1000000; ++n) {
+	sv = (((fastf_t) bn_randmt())) * v0;
+	st = ((fastf_t) bn_randmt()) * M_2PI;
+	mc += sqrt((b2 * c2 * cos(st) * cos(st) * pow(sinh(sv), 4))
+		    + (a2 * c2 * sin(st) * sin(st) * pow(sinh(sv), 4))
+		    + (a2 * b2 * cosh(sv) * cosh(sv) * sinh(sv) * sinh(sv)));
+    }
+    mc *= M_2PI * v0 / n;
+
+    /* Hyperboloid surface + ellipse */
+    *area = mc + M_PI * eip->ehy_r1 * eip->ehy_r2;
 }
 
 

--- a/src/librt/primitives/ehy/ehy.c
+++ b/src/librt/primitives/ehy/ehy.c
@@ -2436,94 +2436,36 @@ C_DECL void
 rt_ehy_surf_area(fastf_t *area, const struct rt_db_internal *ip)
 {
     struct rt_ehy_internal *eip;
-    fastf_t h, r, c, P, alpha, B, sqrtAlpha;
-    fastf_t u_top, u_bot, v_top, v_bot, F_top, F_bot;
-
-    if (!area || !ip)
-	return;
+    fastf_t c, h, scale, a, b, a2, b2, c2, v0, mc, sv, st;
+    int n;
 
     RT_CK_DB_INTERNAL(ip);
     eip = (struct rt_ehy_internal *)ip->idb_ptr;
     RT_EHY_CK_MAGIC(eip);
 
-    /* For the elliptical case (r1 != r2) the lateral surface area requires
-     * an elliptic integral with no elementary closed form -- use Crofton.
-     */
-    if (!NEAR_EQUAL(eip->ehy_r1, eip->ehy_r2, RT_LEN_TOL)) {
-	do { static const struct rt_crofton_params _p = {50000u, 0.0, 0.0}; rt_crofton_sample(area, NULL, ip, &_p); } while (0);
-	return;
-    }
-
-    /* Circular case (r1 == r2 == r): the EHY is a surface of revolution.
-     *
-     * The profile radius at height h_dist along H is:
-     *   y(h_dist) = r * sqrt(((H+c-h_dist)^2 - c^2) / (H*(H+2*c)))
-     *
-     * Substituting u = H+c-h_dist and letting P = H*(H+2*c), the lateral
-     * surface area integral becomes:
-     *   SA_lat = 2*pi*r/P * integral_c^{H+c} sqrt(alpha*u^2 - B) du
-     * where alpha = P + r^2 and B = c^2 * P.
-     *
-     * The integral has the standard antiderivative:
-     *   F(u) = u/2 * sqrt(alpha*u^2 - B)
-     *         - B/(2*sqrt(alpha)) * log(sqrt(alpha)*u + sqrt(alpha*u^2 - B))
-     *
-     * At the lower bound u = c: alpha*c^2 - B = c^2*(alpha-P) = c^2*r^2 > 0.
-     * At the upper bound u = H+c: alpha*(H+c)^2 - B > 0 for any valid EHY.
-     *
-     * The flat circular base contributes pi*r^2.
-     */
-    h = MAGNITUDE(eip->ehy_H);
-    r = eip->ehy_r1;
     c = eip->ehy_c;
-
-    P = h * (h + 2.0*c);		/* H*(H+2c) */
-    alpha = P + r*r;
-    B = c*c * P;
-    sqrtAlpha = sqrt(alpha);
-
-    /* Antiderivative F(u) = u/2*sqrt(alpha*u^2-B)
-     *                       - B/(2*sqrt(alpha)) * log(sqrt(alpha)*u + sqrt(alpha*u^2-B))
-     * evaluated at the bounds of the substituted integral.
-     * At u=c: alpha*c^2-B = c^2*(alpha-P) = c^2*r^2, simplified below.
-     */
-    u_top = h + c;
-    u_bot = c;
-    v_top = alpha*u_top*u_top - B;
-    v_bot = c*c * r*r;  /* = alpha*c^2 - B = c^2*r^2 (exact, avoids cancellation) */
-
-    {
-	fastf_t half_B_over_sqrtAlpha = B / (2.0*sqrtAlpha);
-	F_top = u_top/2.0*sqrt(v_top) - half_B_over_sqrtAlpha*log(sqrtAlpha*u_top + sqrt(v_top));
-	F_bot = u_bot/2.0*sqrt(v_bot) - half_B_over_sqrtAlpha*log(sqrtAlpha*u_bot + sqrt(v_bot));
-    }
-
-    *area = 2.0*M_PI*r/P * (F_top - F_bot) + M_PI*r*r;
-}
-
-
-C_DECL void
-rt_ehy_volume(fastf_t *volume, const struct rt_db_internal *ip)
-{
-    struct rt_ehy_internal *eip;
-    fastf_t h, c;
-
-    if (!volume || !ip)
-	return;
-
-    RT_CK_DB_INTERNAL(ip);
-    eip = (struct rt_ehy_internal *)ip->idb_ptr;
-    RT_EHY_CK_MAGIC(eip);
-
     h = MAGNITUDE(eip->ehy_H);
-    c = eip->ehy_c;
+    scale = c / sqrt(h * (2 * c + h));
+    a = eip->ehy_r1 * scale;
+    b = eip->ehy_r2 * scale;
 
-    /* Each cross-section at height h_dist has elliptical area
-     *   A(h_dist) = pi*r1*r2 * ((H+c-h_dist)^2 - c^2) / (H*(H+2*c))
-     * Integrating from 0 to H yields:
-     *   Vol = pi * r1 * r2 * H * (H + 3*c) / (3 * (H + 2*c))
-     */
-    *volume = M_PI * eip->ehy_r1 * eip->ehy_r2 * h * (h + 3.0*c) / (3.0*(h + 2.0*c));
+    v0 = acosh(1 + h / c);
+    a2 = a * a;
+    b2 = b * b;
+    c2 = c * c;
+
+    /* Monte Carlo integration */
+    for (mc = 0, n = 0; n < 1000000; ++n) {
+	sv = (((fastf_t) bn_randmt())) * v0;
+	st = ((fastf_t) bn_randmt()) * M_2PI;
+	mc += sqrt((b2 * c2 * cos(st) * cos(st) * pow(sinh(sv), 4))
+		    + (a2 * c2 * sin(st) * sin(st) * pow(sinh(sv), 4))
+		    + (a2 * b2 * cosh(sv) * cosh(sv) * sinh(sv) * sinh(sv)));
+    }
+    mc *= M_2PI * v0 / n;
+
+    /* Hyperboloid surface + ellipse */
+    *area = mc + M_PI * eip->ehy_r1 * eip->ehy_r2;
 }
 
 

--- a/src/librt/primitives/ehy/ehy.c
+++ b/src/librt/primitives/ehy/ehy.c
@@ -2527,6 +2527,23 @@ rt_ehy_volume(fastf_t *volume, const struct rt_db_internal *ip)
 }
 
 
+void
+rt_ehy_volume(fastf_t *volume, const struct rt_db_internal *ip)
+{
+    struct rt_ehy_internal *eip;
+    fastf_t c, h, scale;
+
+    RT_CK_DB_INTERNAL(ip);
+    eip = (struct rt_ehy_internal *)ip->idb_ptr;
+    RT_EHY_CK_MAGIC(eip);
+
+    c = eip->ehy_c;
+    h = MAGNITUDE(eip->ehy_H);
+    scale = c / sqrt(h * (2 * c + h));
+    *volume = M_PI * eip->ehy_r1 * scale * eip->ehy_r2 * scale * h * h / (3 * c * c) * (3 * c + h);
+}
+
+
 /**
  * The centroid of the EHY lies along H due to its bilateral symmetry.
  *

--- a/src/librt/primitives/hyp/hyp.c
+++ b/src/librt/primitives/hyp/hyp.c
@@ -1427,12 +1427,44 @@ rt_hyp_centroid(point_t *cent, const struct rt_db_internal *ip)
 }
 
 
-/**
- * only the stub to make analyze happy
- * TODO: needs an implementation
- */
 void
-rt_hyp_surf_area(fastf_t *UNUSED(area), const struct rt_db_internal *UNUSED(ip)) {}
+rt_hyp_surf_area(fastf_t *area, const struct rt_db_internal *ip)
+{
+    struct rt_hyp_internal* hip;
+    struct hyp_specific* hyp;
+    fastf_t c, h, a, b, a2, b2, c2, v0, mc, sv, st;
+    int n;
+
+    RT_CK_DB_INTERNAL(ip);
+    hip = (struct rt_hyp_internal*)ip->idb_ptr;
+    RT_HYP_CK_MAGIC(hip);
+
+    hyp = hyp_internal_to_specific(hip);
+
+    c = hyp->hyp_r1 / hyp->hyp_c;
+    h = hyp->hyp_Hmag;
+    a = hyp->hyp_r1 < hyp->hyp_r2 ? hyp->hyp_r2 : hyp->hyp_r1;
+    b = hyp->hyp_r1 < hyp->hyp_r2 ? hyp->hyp_r1 : hyp->hyp_r2;
+
+    v0 = asinh(h / c);
+    a2 = a * a;
+    b2 = b * b;
+    c2 = c * c;
+
+    /* Monte Carlo integration */
+    for (mc = 0, n = 0; n < 1000000; ++n) {
+	sv = (((fastf_t) bn_randmt())) * v0;
+	st = ((fastf_t) bn_randmt()) * M_2PI;
+	mc += sqrt((b2 * c2 * cos(st) * cos(st) * pow(cosh(sv), 4))
+		    + (a2 * c2 * sin(st) * sin(st) * pow(cosh(sv), 4))
+		    + (a2 * b2 * cosh(sv) * cosh(sv) * sinh(sv) * sinh(sv)));
+    }
+    mc *= 2 * M_2PI * v0 / n;
+
+    /* Hyperboloid surface + two ellipses */
+    *area = mc + M_2PI * MAGNITUDE(hip->hyp_A) * hip->hyp_b;
+    BU_PUT(hyp, struct hyp_specific);
+}
 
 
 void

--- a/src/librt/primitives/hyp/hyp.c
+++ b/src/librt/primitives/hyp/hyp.c
@@ -1441,20 +1441,22 @@ rt_hyp_surf_area(fastf_t *UNUSED(area), const struct rt_db_internal *UNUSED(ip))
 void
 rt_hyp_volume(fastf_t *volume, const struct rt_db_internal *ip)
 {
-    if (volume != NULL && ip != NULL) {
-	struct rt_hyp_internal *hip;
-	struct hyp_specific *hyp;
+    struct rt_hyp_internal *hip;
+    struct hyp_specific *hyp;
+    fastf_t c;
 
-	RT_CK_DB_INTERNAL(ip);
-	hip = (struct rt_hyp_internal *)ip->idb_ptr;
-	RT_HYP_CK_MAGIC(hip);
+    RT_CK_DB_INTERNAL(ip);
+    hip = (struct rt_hyp_internal *)ip->idb_ptr;
+    RT_HYP_CK_MAGIC(hip);
 
-	hyp = hyp_internal_to_specific(hip);
-	*volume = M_2PI * hyp->hyp_r1 * hyp->hyp_r2 * hyp->hyp_Hmag *
-	    (1 + hyp->hyp_Hmag * hyp->hyp_Hmag * hyp->hyp_c * hyp->hyp_c / (12 * hyp->hyp_r1 * hyp->hyp_r1));
-	bu_free(hyp, "hyp volume");
-    }
+    hyp = hyp_internal_to_specific(hip);
+
+    c = hyp->hyp_r1 / hyp->hyp_c;
+
+    *volume = M_2PI * hyp->hyp_r1 * hyp->hyp_r2 * hyp->hyp_Hmag * (1 + hyp->hyp_Hmag * hyp->hyp_Hmag / (3 * c * c));
+    BU_PUT(hyp, struct hyp_specific);
 }
+
 
 int
 rt_hyp_labels(struct rt_point_labels *pl, int pl_max, const mat_t xform, const struct rt_db_internal *ip, const struct bn_tol *UNUSED(tol))

--- a/src/librt/primitives/hyp/hyp.c
+++ b/src/librt/primitives/hyp/hyp.c
@@ -1417,16 +1417,13 @@ rt_hyp_params(struct pc_pc_set * UNUSED(ps), const struct rt_db_internal *ip)
 void
 rt_hyp_centroid(point_t *cent, const struct rt_db_internal *ip)
 {
-    if (cent != NULL && ip != NULL) {
-	struct rt_hyp_internal *hip;
+    struct rt_hyp_internal *hip;
 
-	RT_CK_DB_INTERNAL(ip);
-	hip = (struct rt_hyp_internal *)ip->idb_ptr;
-	RT_HYP_CK_MAGIC(hip);
+    RT_CK_DB_INTERNAL(ip);
+    hip = (struct rt_hyp_internal *)ip->idb_ptr;
+    RT_HYP_CK_MAGIC(hip);
 
-	VSCALE(*cent, hip->hyp_Hi, 0.5);
-	VADD2(*cent, hip->hyp_Vi, *cent);
-    }
+    VJOIN1(*cent, hip->hyp_Vi, 0.5, hip->hyp_Hi);
 }
 
 

--- a/src/librt/primitives/hyp/hyp.c
+++ b/src/librt/primitives/hyp/hyp.c
@@ -1689,17 +1689,43 @@ rt_hyp_centroid(point_t *cent, const struct rt_db_internal *ip)
 }
 
 
-/**
- * Surface area of a hyperboloid of one sheet.
- * There is no known closed-form solution for the general case.
- * Use the Cauchy-Crofton ray-sampling estimator as a fallback.
- */
 C_DECL void
 rt_hyp_surf_area(fastf_t *area, const struct rt_db_internal *ip)
 {
-    if (!area || !ip)
-	return;
-    do { static const struct rt_crofton_params _p = {50000u, 0.0, 0.0}; rt_crofton_sample(area, NULL, ip, &_p); } while (0);
+    struct rt_hyp_internal* hip;
+    struct hyp_specific* hyp;
+    fastf_t c, h, a, b, a2, b2, c2, v0, mc, sv, st;
+    int n;
+
+    RT_CK_DB_INTERNAL(ip);
+    hip = (struct rt_hyp_internal*)ip->idb_ptr;
+    RT_HYP_CK_MAGIC(hip);
+
+    hyp = hyp_internal_to_specific(hip);
+
+    c = hyp->hyp_r1 / hyp->hyp_c;
+    h = hyp->hyp_Hmag;
+    a = hyp->hyp_r1 < hyp->hyp_r2 ? hyp->hyp_r2 : hyp->hyp_r1;
+    b = hyp->hyp_r1 < hyp->hyp_r2 ? hyp->hyp_r1 : hyp->hyp_r2;
+
+    v0 = asinh(h / c);
+    a2 = a * a;
+    b2 = b * b;
+    c2 = c * c;
+
+    /* Monte Carlo integration */
+    for (mc = 0, n = 0; n < 1000000; ++n) {
+	sv = (((fastf_t) bn_randmt())) * v0;
+	st = ((fastf_t) bn_randmt()) * M_2PI;
+	mc += sqrt((b2 * c2 * cos(st) * cos(st) * pow(cosh(sv), 4))
+		    + (a2 * c2 * sin(st) * sin(st) * pow(cosh(sv), 4))
+		    + (a2 * b2 * cosh(sv) * cosh(sv) * sinh(sv) * sinh(sv)));
+    }
+    mc *= 2 * M_2PI * v0 / n;
+
+    /* Hyperboloid surface + two ellipses */
+    *area = mc + M_2PI * MAGNITUDE(hip->hyp_A) * hip->hyp_b;
+    BU_PUT(hyp, struct hyp_specific);
 }
 
 

--- a/src/librt/primitives/hyp/hyp.c
+++ b/src/librt/primitives/hyp/hyp.c
@@ -1679,16 +1679,13 @@ rt_hyp_params(struct pc_pc_set * UNUSED(ps), const struct rt_db_internal *ip)
 C_DECL void
 rt_hyp_centroid(point_t *cent, const struct rt_db_internal *ip)
 {
-    if (cent != NULL && ip != NULL) {
-	struct rt_hyp_internal *hip;
+    struct rt_hyp_internal *hip;
 
-	RT_CK_DB_INTERNAL(ip);
-	hip = (struct rt_hyp_internal *)ip->idb_ptr;
-	RT_HYP_CK_MAGIC(hip);
+    RT_CK_DB_INTERNAL(ip);
+    hip = (struct rt_hyp_internal *)ip->idb_ptr;
+    RT_HYP_CK_MAGIC(hip);
 
-	VSCALE(*cent, hip->hyp_Hi, 0.5);
-	VADD2(*cent, hip->hyp_Vi, *cent);
-    }
+    VJOIN1(*cent, hip->hyp_Vi, 0.5, hip->hyp_Hi);
 }
 
 

--- a/src/librt/primitives/hyp/hyp.c
+++ b/src/librt/primitives/hyp/hyp.c
@@ -1709,20 +1709,20 @@ rt_hyp_surf_area(fastf_t *area, const struct rt_db_internal *ip)
 C_DECL void
 rt_hyp_volume(fastf_t *volume, const struct rt_db_internal *ip)
 {
-    if (volume != NULL && ip != NULL) {
-	struct rt_hyp_internal *hip;
-	struct hyp_specific *hyp;
+    struct rt_hyp_internal *hip;
+    struct hyp_specific *hyp;
+    fastf_t c;
 
-	RT_CK_DB_INTERNAL(ip);
-	hip = (struct rt_hyp_internal *)ip->idb_ptr;
-	RT_HYP_CK_MAGIC(hip);
+    RT_CK_DB_INTERNAL(ip);
+    hip = (struct rt_hyp_internal *)ip->idb_ptr;
+    RT_HYP_CK_MAGIC(hip);
 
-	hyp = hyp_internal_to_specific(hip);
-	*volume = M_2PI * hyp->hyp_r1 * hyp->hyp_r2 * hyp->hyp_Hmag *
-	    (1 + hyp->hyp_Hmag * hyp->hyp_Hmag * hyp->hyp_c * hyp->hyp_c / (12 * hyp->hyp_r1 * hyp->hyp_r1));
-	bu_free(hyp, "hyp volume");
-    }
+    hyp = hyp_internal_to_specific(hip);
+    c = hyp->hyp_r1 / hyp->hyp_c;
+    *volume = M_2PI * hyp->hyp_r1 * hyp->hyp_r2 * hyp->hyp_Hmag * (1 + hyp->hyp_Hmag * hyp->hyp_Hmag / (3 * c * c));
+    BU_PUT(hyp, struct hyp_specific);
 }
+
 
 C_DECL int
 rt_hyp_labels(struct rt_point_labels *pl, int pl_max, const mat_t xform, const struct rt_db_internal *ip, const struct bn_tol *UNUSED(tol))

--- a/src/librt/primitives/rhc/rhc.c
+++ b/src/librt/primitives/rhc/rhc.c
@@ -1909,17 +1909,11 @@ rt_rhc_surf_area(fastf_t *area, const struct rt_db_internal *ip)
 }
 
 
-/**
- * Computer volume of a right hyperbolic cylinder
- */
 void
 rt_rhc_volume(fastf_t *volume, const struct rt_db_internal *ip)
 {
     struct rt_rhc_internal *rip;
-    fastf_t A, integralArea, a, b, magB, sqrt_ra, height;
-    if (volume == NULL || ip == NULL) {
-	return;
-    }
+    fastf_t a, b, magB, sqrt_bb, A, height;
 
     RT_CK_DB_INTERNAL(ip);
     rip = (struct rt_rhc_internal *)ip->idb_ptr;
@@ -1929,9 +1923,9 @@ rt_rhc_volume(fastf_t *volume, const struct rt_db_internal *ip)
     magB = MAGNITUDE(rip->rhc_B);
     height = MAGNITUDE(rip->rhc_H);
     a = (rip->rhc_r * b) / sqrt(magB * (2.0 * rip->rhc_c + magB));
-    sqrt_ra = sqrt(rip->rhc_r * rip->rhc_r + a * a);
-    integralArea = (b / a) * ((2.0 * rip->rhc_r * sqrt_ra) / 2.0 + ((a * a) / 2.0) * (log(sqrt_ra + rip->rhc_r) - log(sqrt_ra - rip->rhc_r)));
-    A = 2.0 * rip->rhc_r * (rip->rhc_c + magB) - integralArea;
+
+    sqrt_bb = sqrt(magB * (2 * b + magB));
+    A = a * ((b + magB) / b * sqrt_bb - b * log(sqrt_bb + b + magB) + b * log(b));
 
     *volume = A * height;
 }

--- a/src/librt/primitives/rhc/rhc.c
+++ b/src/librt/primitives/rhc/rhc.c
@@ -1605,7 +1605,7 @@ rt_rhc_mat(struct rt_db_internal *rop, const mat_t mat, const struct rt_db_inter
     VMOVE(rB, tip->rhc_B);
     double rhc_r = tip->rhc_r / mat[15];
     double rhc_c = tip->rhc_c / mat[15];
- 
+
     if (rhc_r <= SMALL_FASTF || rhc_c <= SMALL_FASTF) {
 	bu_log("rt_rhc_mat: r or c are zero\n");
 	return BRLCAD_ERROR;
@@ -1655,7 +1655,7 @@ rt_rhc_import5(struct rt_db_internal *ip, const struct bu_external *ep, const fa
     if (mat == NULL)
 	mat = bn_mat_identity;
 
-    /* Sanity check */ 
+    /* Sanity check */
     double rhc_r = vec[3 * 3] / mat[15];
     double rhc_c = vec[3 * 3 + 1] / mat[15];
      if (rhc_r <= SMALL_FASTF || rhc_c <= SMALL_FASTF) {
@@ -1854,11 +1854,8 @@ void
 rt_rhc_surf_area(fastf_t *area, const struct rt_db_internal *ip)
 {
     struct rt_rhc_internal *rip;
-    fastf_t A, arclen, integralArea, a, b, magB, sqrt_ra, height;
-
-    fastf_t h;
-    fastf_t sumodds = 0, sumevens = 0, x = 0;
-    int i, j;
+    fastf_t a, b, magB, sqrt_bb, A, height, arclen, h, x, a2, b2;
+    int i;
 
     /**
      * n is the number of divisions to use when using Simpson's
@@ -1878,10 +1875,6 @@ rt_rhc_surf_area(fastf_t *area, const struct rt_db_internal *ip)
      */
     int n = 1000000;
 
-    if (area == NULL || ip == NULL) {
-	return;
-    }
-
     RT_CK_DB_INTERNAL(ip);
     rip = (struct rt_rhc_internal *)ip->idb_ptr;
     RT_RHC_CK_MAGIC(rip);
@@ -1890,22 +1883,26 @@ rt_rhc_surf_area(fastf_t *area, const struct rt_db_internal *ip)
     magB = MAGNITUDE(rip->rhc_B);
     height = MAGNITUDE(rip->rhc_H);
     a = (rip->rhc_r * b) / sqrt(magB * (2.0 * rip->rhc_c + magB));
-    sqrt_ra = sqrt(rip->rhc_r * rip->rhc_r + a * a);
-    integralArea = (b / a) * ((2.0 * rip->rhc_r * sqrt_ra) / 2.0 + ((a * a) / 2.0) * (log(sqrt_ra + rip->rhc_r) - log(sqrt_ra - rip->rhc_r)));
-    A = 2.0 * rip->rhc_r * (rip->rhc_c + magB) - integralArea;
 
-    h = (2.0 * rip->rhc_r) / n;
+    sqrt_bb = sqrt(magB * (2 * b + magB));
+    A = a * ((b + magB) / b * sqrt_bb - b * log(sqrt_bb + b + magB) + b * log(b));
+
+    h = (2 * rip->rhc_r) / n;
+    a2 = a * a;
+    b2 = b * b;
+    arclen = 2 * sqrt((b2 * rip->rhc_r * rip->rhc_r) / (a2 * rip->rhc_r * rip->rhc_r + pow(a, 4)) + 1);
     for (i = 1; i <= (n / 2) - 1; i++) {
-	x = -rip->rhc_r + 2.0 * i * h;
-	sumodds += sqrt((b * b * x * x) / (a * a * x * x + pow(a, 4.0)) + 1.0);
+	x = -rip->rhc_r + 2 * i * h;
+	arclen += 2 * sqrt((b2 * x * x) / (a2 * x * x + a2 * a2) + 1);
     }
-    for (j = 1; j <= (n / 2); j++) {
-	x = -rip->rhc_r + (2.0 * j - 1.0) * h;
-	sumevens += sqrt((b * b * x * x) / (a * a * x * x + pow(a, 4.0)) + 1.0);
+    for (i = 1; i <= (n / 2); i++) {
+	x = -rip->rhc_r + (2 * i - 1) * h;
+	arclen += 4 * sqrt((b2 * x * x) / (a2 * x * x + a2 * a2) + 1);
     }
-    arclen = (h / 3.0) * (sqrt((b * b * rip->rhc_r * rip->rhc_r) / (a * a * rip->rhc_r * rip->rhc_r + pow(a, 4.0)) + 1.0) + 2.0 * sumodds + 4.0 * sumevens + sqrt((b * b * rip->rhc_r * rip->rhc_r) / (a * a * rip->rhc_r * rip->rhc_r + pow(a, 4.0)) + 1.0));
+    arclen *= h / 3;
 
-    *area = 2.0 * A + 2.0 * rip->rhc_r * height + arclen * height;
+    /* Two hyperbola areas + rectangular face + extruded hyperbola */
+    *area = 2 * A + 2 * rip->rhc_r * height + arclen * height;
 }
 
 

--- a/src/librt/primitives/rhc/rhc.c
+++ b/src/librt/primitives/rhc/rhc.c
@@ -1931,56 +1931,26 @@ rt_rhc_volume(fastf_t *volume, const struct rt_db_internal *ip)
 }
 
 
-/**
- * Computes centroid of a right hyperbolic cylinder
- */
 void
 rt_rhc_centroid(point_t *cent, const struct rt_db_internal *ip)
 {
-    if (cent != NULL && ip != NULL) {
-	struct rt_rhc_internal *rip;
-	fastf_t totalArea, guessArea, a, b, magB, sqrt_xa, sqrt_ga, xf, epsilon, high, low, scale_factor;
-	fastf_t guess = 0.0;
-	vect_t shift_h;
+    struct rt_rhc_internal *rip;
+    fastf_t b, magB, sqrt_bb, num, den, scale_factor;
 
-	RT_CK_DB_INTERNAL(ip);
-	rip = (struct rt_rhc_internal *)ip->idb_ptr;
-	RT_RHC_CK_MAGIC(rip);
+    RT_CK_DB_INTERNAL(ip);
+    rip = (struct rt_rhc_internal *)ip->idb_ptr;
+    RT_RHC_CK_MAGIC(rip);
 
-	magB = MAGNITUDE(rip->rhc_B);
-	b = rip->rhc_c;
-	a = (rip->rhc_r * b) / sqrt(magB * (2 * rip->rhc_c + magB));
-	xf = magB + a;
+    b = rip->rhc_c;
+    magB = MAGNITUDE(rip->rhc_B);
 
-	/* epsilon is an upperbound on the error */
-
-	epsilon = 0.0001;
-
-	sqrt_xa = sqrt((xf * xf) - (a * a));
-	totalArea = (b / a) * ((xf * sqrt_xa) - ((a * a) * log(sqrt_xa + xf)) - ((a * a) * log(xf)));
-
-	low = a;
-	high = xf;
-
-	while (fabs(high - low) > epsilon) {
-	    guess = (high + low) / 2.0;
-	    sqrt_ga = sqrt((guess * guess) - (a * a));
-	    guessArea = (b / a) * ((guess * sqrt_ga) - ((a * a) * log(sqrt_ga + guess)) - ((a * a) * log(guess)));
-
-	    if (guessArea > totalArea / 2.0) {
-		high = guess;
-	    } else {
-		low = guess;
-	    }
-	}
-
-	scale_factor = 1.0 - ((guess - a) / magB);
-
-	VSCALE(shift_h, rip->rhc_H, 0.5);
-	VSCALE(*cent, rip->rhc_B, scale_factor);
-	VADD2(*cent, shift_h, *cent);
-    }
+    sqrt_bb = sqrt(magB * (2 * b + magB));
+    num = 2.0 / 3.0 * pow(sqrt_bb, 3);
+    den = (b + magB) * sqrt_bb - b * b * log(sqrt_bb + b + magB) + b * b * log(b);
+    scale_factor = (magB + b - num / den) / magB;
+    VJOIN2(*cent, rip->rhc_V, 0.5, rip->rhc_H, scale_factor, rip->rhc_B);
 }
+
 
 int
 rt_rhc_labels(struct rt_point_labels *pl, int pl_max, const mat_t xform, const struct rt_db_internal *ip, const struct bn_tol *UNUSED(tol))

--- a/src/librt/primitives/rhc/rhc.c
+++ b/src/librt/primitives/rhc/rhc.c
@@ -1917,7 +1917,7 @@ rt_rhc_mat(struct rt_db_internal *rop, const mat_t mat, const struct rt_db_inter
     VMOVE(rB, tip->rhc_B);
     double rhc_r = tip->rhc_r / mat[15];
     double rhc_c = tip->rhc_c / mat[15];
- 
+
     if (rhc_r <= SMALL_FASTF || rhc_c <= SMALL_FASTF) {
 	bu_log("rt_rhc_mat: r or c are zero\n");
 	return BRLCAD_ERROR;
@@ -1967,7 +1967,7 @@ rt_rhc_import5(struct rt_db_internal *ip, const struct bu_external *ep, const fa
     if (mat == NULL)
 	mat = bn_mat_identity;
 
-    /* Sanity check */ 
+    /* Sanity check */
     double rhc_r = vec[3 * 3] / mat[15];
     double rhc_c = vec[3 * 3 + 1] / mat[15];
      if (rhc_r <= SMALL_FASTF || rhc_c <= SMALL_FASTF) {
@@ -2222,17 +2222,11 @@ rt_rhc_surf_area(fastf_t *area, const struct rt_db_internal *ip)
 }
 
 
-/**
- * Computer volume of a right hyperbolic cylinder
- */
 C_DECL void
 rt_rhc_volume(fastf_t *volume, const struct rt_db_internal *ip)
 {
     struct rt_rhc_internal *rip;
-    fastf_t A, integralArea, a, b, magB, sqrt_ra, height;
-    if (volume == NULL || ip == NULL) {
-	return;
-    }
+    fastf_t a, b, magB, sqrt_bb, A, height;
 
     RT_CK_DB_INTERNAL(ip);
     rip = (struct rt_rhc_internal *)ip->idb_ptr;
@@ -2242,9 +2236,9 @@ rt_rhc_volume(fastf_t *volume, const struct rt_db_internal *ip)
     magB = MAGNITUDE(rip->rhc_B);
     height = MAGNITUDE(rip->rhc_H);
     a = (rip->rhc_r * b) / sqrt(magB * (2.0 * rip->rhc_c + magB));
-    sqrt_ra = sqrt(rip->rhc_r * rip->rhc_r + a * a);
-    integralArea = (b / a) * ((2.0 * rip->rhc_r * sqrt_ra) / 2.0 + ((a * a) / 2.0) * (log(sqrt_ra + rip->rhc_r) - log(sqrt_ra - rip->rhc_r)));
-    A = 2.0 * rip->rhc_r * (rip->rhc_c + magB) - integralArea;
+
+    sqrt_bb = sqrt(magB * (2 * b + magB));
+    A = a * ((b + magB) / b * sqrt_bb - b * log(sqrt_bb + b + magB) + b * log(b));
 
     *volume = A * height;
 }

--- a/src/librt/primitives/rhc/rhc.c
+++ b/src/librt/primitives/rhc/rhc.c
@@ -2244,55 +2244,24 @@ rt_rhc_volume(fastf_t *volume, const struct rt_db_internal *ip)
 }
 
 
-/**
- * Computes centroid of a right hyperbolic cylinder
- */
 C_DECL void
 rt_rhc_centroid(point_t *cent, const struct rt_db_internal *ip)
 {
-    if (cent != NULL && ip != NULL) {
-	struct rt_rhc_internal *rip;
-	fastf_t totalArea, guessArea, a, b, magB, sqrt_xa, sqrt_ga, xf, epsilon, high, low, scale_factor;
-	fastf_t guess = 0.0;
-	vect_t shift_h;
+    struct rt_rhc_internal *rip;
+    fastf_t b, magB, sqrt_bb, num, den, scale_factor;
 
-	RT_CK_DB_INTERNAL(ip);
-	rip = (struct rt_rhc_internal *)ip->idb_ptr;
-	RT_RHC_CK_MAGIC(rip);
+    RT_CK_DB_INTERNAL(ip);
+    rip = (struct rt_rhc_internal *)ip->idb_ptr;
+    RT_RHC_CK_MAGIC(rip);
 
-	magB = MAGNITUDE(rip->rhc_B);
-	b = rip->rhc_c;
-	a = (rip->rhc_r * b) / sqrt(magB * (2 * rip->rhc_c + magB));
-	xf = magB + a;
+    b = rip->rhc_c;
+    magB = MAGNITUDE(rip->rhc_B);
 
-	/* epsilon is an upperbound on the error */
-
-	epsilon = 0.0001;
-
-	sqrt_xa = sqrt((xf * xf) - (a * a));
-	totalArea = (b / a) * ((xf * sqrt_xa) - ((a * a) * log(sqrt_xa + xf)) - ((a * a) * log(xf)));
-
-	low = a;
-	high = xf;
-
-	while (fabs(high - low) > epsilon) {
-	    guess = (high + low) / 2.0;
-	    sqrt_ga = sqrt((guess * guess) - (a * a));
-	    guessArea = (b / a) * ((guess * sqrt_ga) - ((a * a) * log(sqrt_ga + guess)) - ((a * a) * log(guess)));
-
-	    if (guessArea > totalArea / 2.0) {
-		high = guess;
-	    } else {
-		low = guess;
-	    }
-	}
-
-	scale_factor = 1.0 - ((guess - a) / magB);
-
-	VSCALE(shift_h, rip->rhc_H, 0.5);
-	VSCALE(*cent, rip->rhc_B, scale_factor);
-	VADD2(*cent, shift_h, *cent);
-    }
+    sqrt_bb = sqrt(magB * (2 * b + magB));
+    num = 2.0 / 3.0 * pow(sqrt_bb, 3);
+    den = (b + magB) * sqrt_bb - b * b * log(sqrt_bb + b + magB) + b * b * log(b);
+    scale_factor = (magB + b - num / den) / magB;
+    VJOIN2(*cent, rip->rhc_V, 0.5, rip->rhc_H, scale_factor, rip->rhc_B);
 }
 
 C_DECL int

--- a/src/librt/primitives/rhc/rhc.c
+++ b/src/librt/primitives/rhc/rhc.c
@@ -2167,11 +2167,8 @@ C_DECL void
 rt_rhc_surf_area(fastf_t *area, const struct rt_db_internal *ip)
 {
     struct rt_rhc_internal *rip;
-    fastf_t A, arclen, integralArea, a, b, magB, sqrt_ra, height;
-
-    fastf_t h;
-    fastf_t sumodds = 0, sumevens = 0, x = 0;
-    int i, j;
+    fastf_t a, b, magB, sqrt_bb, A, height, arclen, h, x, a2, b2;
+    int i;
 
     /**
      * n is the number of divisions to use when using Simpson's
@@ -2191,10 +2188,6 @@ rt_rhc_surf_area(fastf_t *area, const struct rt_db_internal *ip)
      */
     int n = 1000000;
 
-    if (area == NULL || ip == NULL) {
-	return;
-    }
-
     RT_CK_DB_INTERNAL(ip);
     rip = (struct rt_rhc_internal *)ip->idb_ptr;
     RT_RHC_CK_MAGIC(rip);
@@ -2203,22 +2196,26 @@ rt_rhc_surf_area(fastf_t *area, const struct rt_db_internal *ip)
     magB = MAGNITUDE(rip->rhc_B);
     height = MAGNITUDE(rip->rhc_H);
     a = (rip->rhc_r * b) / sqrt(magB * (2.0 * rip->rhc_c + magB));
-    sqrt_ra = sqrt(rip->rhc_r * rip->rhc_r + a * a);
-    integralArea = (b / a) * ((2.0 * rip->rhc_r * sqrt_ra) / 2.0 + ((a * a) / 2.0) * (log(sqrt_ra + rip->rhc_r) - log(sqrt_ra - rip->rhc_r)));
-    A = 2.0 * rip->rhc_r * (rip->rhc_c + magB) - integralArea;
 
-    h = (2.0 * rip->rhc_r) / n;
+    sqrt_bb = sqrt(magB * (2 * b + magB));
+    A = a * ((b + magB) / b * sqrt_bb - b * log(sqrt_bb + b + magB) + b * log(b));
+
+    h = (2 * rip->rhc_r) / n;
+    a2 = a * a;
+    b2 = b * b;
+    arclen = 2 * sqrt((b2 * rip->rhc_r * rip->rhc_r) / (a2 * rip->rhc_r * rip->rhc_r + pow(a, 4)) + 1);
     for (i = 1; i <= (n / 2) - 1; i++) {
-	x = -rip->rhc_r + 2.0 * i * h;
-	sumodds += sqrt((b * b * x * x) / (a * a * x * x + pow(a, 4.0)) + 1.0);
+	x = -rip->rhc_r + 2 * i * h;
+	arclen += 2 * sqrt((b2 * x * x) / (a2 * x * x + a2 * a2) + 1);
     }
-    for (j = 1; j <= (n / 2); j++) {
-	x = -rip->rhc_r + (2.0 * j - 1.0) * h;
-	sumevens += sqrt((b * b * x * x) / (a * a * x * x + pow(a, 4.0)) + 1.0);
+    for (i = 1; i <= (n / 2); i++) {
+	x = -rip->rhc_r + (2 * i - 1) * h;
+	arclen += 4 * sqrt((b2 * x * x) / (a2 * x * x + a2 * a2) + 1);
     }
-    arclen = (h / 3.0) * (sqrt((b * b * rip->rhc_r * rip->rhc_r) / (a * a * rip->rhc_r * rip->rhc_r + pow(a, 4.0)) + 1.0) + 2.0 * sumodds + 4.0 * sumevens + sqrt((b * b * rip->rhc_r * rip->rhc_r) / (a * a * rip->rhc_r * rip->rhc_r + pow(a, 4.0)) + 1.0));
+    arclen *= h / 3;
 
-    *area = 2.0 * A + 2.0 * rip->rhc_r * height + arclen * height;
+    /* Two hyperbola areas + rectangular face + extruded hyperbola */
+    *area = 2 * A + 2 * rip->rhc_r * height + arclen * height;
 }
 
 

--- a/src/librt/primitives/table.cpp
+++ b/src/librt/primitives/table.cpp
@@ -1226,7 +1226,7 @@ const struct rt_functab OBJ[] = {
 	RTFUNCTAB_FUNC_MAKE_CAST(rt_ehy_make),
 	RTFUNCTAB_FUNC_PARAMS_CAST(rt_ehy_params),
 	RTFUNCTAB_FUNC_BBOX_CAST(rt_ehy_bbox),
-	NULL, /* volume */
+	RTFUNCTAB_FUNC_VOLUME_CAST(rt_ehy_volume),
 	RTFUNCTAB_FUNC_SURF_AREA_CAST(rt_ehy_surf_area),
 	RTFUNCTAB_FUNC_CENTROID_CAST(rt_ehy_centroid),
 	NULL, /* oriented_bbox */
@@ -2501,11 +2501,11 @@ const struct rt_functab OBJ[] = {
 	NULL, /* parse */
 	sizeof(struct rt_script_internal),
 	RT_SCRIPT_INTERNAL_MAGIC,
-	RTFUNCTAB_FUNC_GET_CAST(rt_script_get), 
-	RTFUNCTAB_FUNC_ADJUST_CAST(rt_script_adjust), 
-	RTFUNCTAB_FUNC_FORM_CAST(rt_script_form), 
+	RTFUNCTAB_FUNC_GET_CAST(rt_script_get),
+	RTFUNCTAB_FUNC_ADJUST_CAST(rt_script_adjust),
+	RTFUNCTAB_FUNC_FORM_CAST(rt_script_form),
 	RTFUNCTAB_FUNC_MAKE_CAST(rt_script_make),
-	RTFUNCTAB_FUNC_PARAMS_CAST(rt_script_params), 
+	RTFUNCTAB_FUNC_PARAMS_CAST(rt_script_params),
 	NULL, /* bbox */
 	NULL, /* volume */
 	NULL, /* surf_area */
@@ -2743,7 +2743,7 @@ rt_id_solid(struct bu_external *ep)
 	    break;
 	case DBID_SCRIPT:
 	    id = ID_SCRIPT;
-	    break; 
+	    break;
 	default:
 	    bu_log("rt_id_solid:  u_id=x%x unknown\n", rec->u_id);
 	    id = ID_NULL;		/* BAD */
@@ -2784,4 +2784,3 @@ rt_get_functab_by_label(const char *label)
 // c-file-style: "stroustrup"
 // End:
 // ex: shiftwidth=4 tabstop=8
-

--- a/src/librt/primitives/table.cpp
+++ b/src/librt/primitives/table.cpp
@@ -2573,11 +2573,11 @@ const struct rt_functab OBJ[] = {
 	NULL, /* parse */
 	sizeof(struct rt_script_internal),
 	RT_SCRIPT_INTERNAL_MAGIC,
-	RTFUNCTAB_FUNC_GET_CAST(rt_script_get), 
-	RTFUNCTAB_FUNC_ADJUST_CAST(rt_script_adjust), 
-	RTFUNCTAB_FUNC_FORM_CAST(rt_script_form), 
+	RTFUNCTAB_FUNC_GET_CAST(rt_script_get),
+	RTFUNCTAB_FUNC_ADJUST_CAST(rt_script_adjust),
+	RTFUNCTAB_FUNC_FORM_CAST(rt_script_form),
 	RTFUNCTAB_FUNC_MAKE_CAST(rt_script_make),
-	RTFUNCTAB_FUNC_PARAMS_CAST(rt_script_params), 
+	RTFUNCTAB_FUNC_PARAMS_CAST(rt_script_params),
 	NULL, /* bbox */
 	NULL, /* volume */
 	NULL, /* surf_area */
@@ -2818,7 +2818,7 @@ rt_id_solid(struct bu_external *ep)
 	    break;
 	case DBID_SCRIPT:
 	    id = ID_SCRIPT;
-	    break; 
+	    break;
 	default:
 	    bu_log("rt_id_solid:  u_id=x%x unknown\n", rec->u_id);
 	    id = ID_NULL;		/* BAD */


### PR DESCRIPTION
Many years ago I contributed some volume/centroid/surface area calculations to this project as part of Google Code-in. However, some of my equations were wrong or inefficient and it's been on my mind for a while to fix them. So here are fixes for the `ehy`, `hyp` and `rhc` primitives. I've also added `rt_ehy_volume` which did not previously exist. I've compared these outputs with those from `check volume` and `check surf_area` and they are quite close.

Some of the calculations require approximation due to having integrals without a closed-form solution. In particular I have used Monte Carlo integration for the surface area integrals since they are double integrals, but I do not know the optimal number of steps to get good convergence.