### PR TITLE
Fix ELEMENT_BEAM multi-card parsing in k-g converter

### DIFF
--- a/src/conv/k-g/k_parser.cpp
+++ b/src/conv/k-g/k_parser.cpp
@@ -1443,6 +1443,10 @@ bool parse_k
 
 			    pid = stoi(tokens[1]);
 			    data.parts[pid].elements.insert(eid);
+
+			    if (beamOptions.size() > 0)
+				++optionsCounter;
+
 			    break;
 			}
 			else if ((beamOptions.size() > 0)) {
@@ -1623,6 +1627,9 @@ bool parse_k
 				default:
 				    break;
 			    }
+
+			    if (optionsCounter >= beamOptions.size())
+				optionsCounter = 0;
 			}
 
 			break;

--- a/src/conv/k-g/k_parser.cpp
+++ b/src/conv/k-g/k_parser.cpp
@@ -446,6 +446,7 @@ bool parse_k
 	std::string              sectionTitle;
 	bool                     sectionHasOption = false;
 	int                      sectionId        = -1;
+	int                      elementId        = -1;
 	int                      sectionElForm    = 0;
 	//int                      CST              = 0;
 	std::string              line             = read_line(is);
@@ -1422,27 +1423,26 @@ bool parse_k
 		    case KState::Element_Beam: {
 			KElement element;
 			int      pid = 1;
-			int      eid = 1;
 
 			if (beamOptions.size() == 0 || optionsCounter == 0) {
 			    if (tokens.size() < 10) {
 				std::cout << "Too short ELEMENT_BEAM in k-file" << fileName << std::endl;
 				break;
 			    }
-			    eid = stoi(tokens[0]);
+			    elementId = stoi(tokens[0]);
 
-			    if (data.elements.find(eid) != data.elements.end()) {
-				std::cout << "Duplicat Element ID" << eid << " in k-file" << fileName << std::endl;
+			    if (data.elements.find(elementId) != data.elements.end()) {
+				std::cout << "Duplicat Element ID" << elementId << " in k-file" << fileName << std::endl;
 				break;
 			    }
 
 			    for (int i_n = 0; i_n < 3; ++i_n)
 				element.nodes.push_back(stoi(tokens[i_n + FirstNode]));
 
-			    data.elements[eid] = element;
+			    data.elements[elementId] = element;
 
 			    pid = stoi(tokens[1]);
-			    data.parts[pid].elements.insert(eid);
+			    data.parts[pid].elements.insert(elementId);
 
 			    if (beamOptions.size() > 0)
 				++optionsCounter;
@@ -1468,10 +1468,8 @@ bool parse_k
 
 				    for (size_t i_p = 0; i_p < tokens.size(); ++i_p) {
 					double param = stod(tokens[i_p]);
-					element.options["THICKNESS"].push_back(param);
+					data.elements[elementId].options["THICKNESS"].push_back(param);
 				    }
-
-				    data.elements[eid] = element;
 
 				    ++optionsCounter;
 				    break;
@@ -1541,14 +1539,12 @@ bool parse_k
 				    else if (tokens[0] == "SECTION_22")
 					temp = 22.0;
 
-				    element.options["SECTION"].push_back(temp);
+				    data.elements[elementId].options["SECTION"].push_back(temp);
 
 				    for (size_t i_p = 1; i_p < tokens.size(); ++i_p) {
 					temp = stod(tokens[1]);
-					element.options["SECTION"].push_back(temp);
+					data.elements[elementId].options["SECTION"].push_back(temp);
 				    }
-
-				    data.elements[eid] = element;
 				    ++optionsCounter;
 				    break;
 				}
@@ -1567,10 +1563,8 @@ bool parse_k
 
 				    for (size_t i_p = 0; i_p < tokens.size(); ++i_p) {
 					double temp = stod(tokens[i_p]);
-					element.options["OFFSET"].push_back(temp);
+					data.elements[elementId].options["OFFSET"].push_back(temp);
 				    }
-
-				    data.elements[eid] = element;
 
 				    ++optionsCounter;
 				    break;
@@ -1584,10 +1578,8 @@ bool parse_k
 
 				    for (size_t i_p = 0; i_p < tokens.size(); ++i_p) {
 					double temp = stod(tokens[i_p]);
-					element.options["ORIENTATION"].push_back(temp);
+					data.elements[elementId].options["ORIENTATION"].push_back(temp);
 				    }
-
-				    data.elements[eid] = element;
 
 				    ++optionsCounter;
 				    break;
@@ -1601,10 +1593,8 @@ bool parse_k
 
 				    for (size_t i_p = 0; i_p < tokens.size(); ++i_p) {
 					double temp = stod(tokens[i_p]);
-					element.options["WARPAGE"].push_back(temp);
+					data.elements[elementId].options["WARPAGE"].push_back(temp);
 				    }
-
-				    data.elements[eid] = element;
 
 				    ++optionsCounter;
 				    break;
@@ -1616,9 +1606,7 @@ bool parse_k
 					break;
 				    }
 				    double temp = stod(tokens[0]);
-				    element.options["ELBOW"].push_back(temp);
-
-				    data.elements[eid] = element;
+				    data.elements[elementId].options["ELBOW"].push_back(temp);
 
 				    ++optionsCounter;
 				    break;


### PR DESCRIPTION
## Summary
- Fix optionsCounter not incrementing after Card 1, causing option cards 
  (THICKNESS, SECTION, etc.) to be misrouted back to the Card 1 branch 
  with "Too short ELEMENT_BEAM" error
- Fix local variables (eid, element) resetting on every line, causing 
  option data to overwrite stored elements with empty data

## Test file
```
*KEYWORD
*TITLE
Test ELEMENT_BEAM_THICKNESS bug
$
*NODE
       1 0.000000000e+00 0.000000000e+00 0.000000000e+00
       2 1.000000000e+01 0.000000000e+00 0.000000000e+00
       3 0.000000000e+00 1.000000000e+00 0.000000000e+00
       4 2.000000000e+01 1.000000000e+01 0.000000000e+00
$
*MAT_ELASTIC
         1 7.850e-09 2.100e+05 3.000e-01
$
*SECTION_BEAM_TITLE
Beam Section 1
       1       1   1.0000000e+00   0.0000000e+00       1       0
   5.0000000e+00   5.0000000e+00   2.0000000e+00   2.0000000e+00   0.0000000e+00   0.0000000e+00
$
*PART
Beam Part
         1         1         1
$
*ELEMENT_BEAM_THICKNESS
       1       1       1       2       3       0       0       0       0       2
   6.0000000e+00   6.0000000e+00   3.0000000e+00   3.0000000e+00   0.0000000e+00
       2       1       2       4       3       0       0       0       0       2
   8.0000000e+00   8.0000000e+00   4.0000000e+00   4.0000000e+00   0.0000000e+00
$
*END
```

## Before fix
- Card 2 (options data) enters Card 1 branch → "Too short ELEMENT_BEAM" error
- THICKNESS parameters are silently lost

## After fix
- Option cards are correctly routed to the options branch
- Element data persists across cards via persistent elementId variable
- Both beam elements parse and render correctly