### PR TITLE
Csg2g

### DIFF
--- a/doc/asciidoc/system/man1/CMakeLists.txt
+++ b/doc/asciidoc/system/man1/CMakeLists.txt
@@ -34,6 +34,7 @@ set(
   coil.adoc
   comgeom-g.adoc
   conv-vg2g.adoc
+  csg-g.adoc
   cv.adoc
   dbupgrade.adoc
   decimate.adoc
@@ -70,6 +71,7 @@ set(
   g-obj.adoc
   g-ply.adoc
   g-raw.adoc
+  g-scad.adoc
   g-shell-rect.adoc
   g-step.adoc
   g-stl.adoc

--- a/doc/asciidoc/system/man1/csg-g.adoc
+++ b/doc/asciidoc/system/man1/csg-g.adoc
@@ -1,0 +1,61 @@
+= CSG-G(1)
+:doctype: manpage
+:mansource: BRL-CAD
+:manmanual: User Commands
+
+== NAME
+csg-g - OpenSCAD CSG Translator (CSG to BRL-CAD)
+
+== SYNOPSIS
+
+[source]
+----
+csg-g [-d] file.csg file.g
+----
+
+
+[[description]]
+== DESCRIPTION
+
+*csg-g* converts an OpenSCAD evaluated CSG file (_file.csg_) to a BRL-CAD _file.g_ file. The CSG format is produced by running `openscad -o file.csg input.scad` and contains the fully evaluated CSG tree with all variables, modules, and loops resolved.
+
+The converter preserves CSG structure, mapping OpenSCAD primitives and boolean operations directly to BRL-CAD equivalents rather than tessellating to mesh. Supported primitives include cube (RPP), sphere (SPH), cylinder (TGC), polyhedron (ARB or BOT), torus via rotate_extrude of circle (TOR), and extrusions of square, circle, and polygon profiles (RPP, TGC, or sketch+extrusion). Boolean operations (difference, union, intersection, group) and transformation matrices (multmatrix) are preserved. Colors are stored as object attributes. The `import()` node reads and inlines referenced STL files as BOT primitives.
+
+Polyhedra are matched against ARB4, ARB5, and ARB8 when the vertex and face counts match and the shape is convex. Non-convex polyhedra and unmatched shapes fall back to BOT (bag of triangles).
+
+The *-d* option prints debugging information during conversion.
+
+
+[[example]]
+== EXAMPLE
+
+
+----
+
+$ openscad -o model.csg model.scad
+$ csg-g model.csg model.g
+----
+
+
+[[see_also]]
+== SEE ALSO
+
+*g-scad*(1), *stl-g*(1), *openscad*(1)
+
+
+[[author]]
+== AUTHOR
+
+BRL-CAD Team
+
+
+[[copyright]]
+== COPYRIGHT
+
+This software is Copyright (c) 2025 by the United States Government as represented by U.S. Army Research Laboratory.
+
+
+[[bug_reports]]
+== BUG REPORTS
+
+Reports of bugs or problems should be submitted via electronic mail to devs@brlcad.org

--- a/doc/asciidoc/system/man1/g-scad.adoc
+++ b/doc/asciidoc/system/man1/g-scad.adoc
@@ -1,0 +1,59 @@
+= G-SCAD(1)
+:doctype: manpage
+:mansource: BRL-CAD
+:manmanual: User Commands
+
+== NAME
+g-scad - BRL-CAD to OpenSCAD Translator (BRL-CAD to SCAD)
+
+== SYNOPSIS
+
+[source]
+----
+g-scad [-d] [-o output.scad] file.g object(s)
+----
+
+
+[[description]]
+== DESCRIPTION
+
+*g-scad* converts the specified BRL-CAD objects from _file.g_ to OpenSCAD format. The output preserves CSG structure, mapping BRL-CAD boolean operations and primitives directly to OpenSCAD equivalents rather than tessellating everything to polyhedron.
+
+Direct primitive mappings: SPH and ELL to sphere(), TGC and REC to cylinder(), ARB to polyhedron(), BOT to polyhedron(), TOR to rotate_extrude(circle()), PARTICLE to hull() of two spheres, PIPE to union of cylinders and spheres, EXTRUDE to linear_extrude(polygon()), REVOLVE to rotate_extrude(polygon()), and HALF to a large translated cube. Combination colors are emitted as color() wrappers. Primitives without direct mappings are tessellated via their ft_tessellate method and emitted as polyhedron().
+
+The *-d* option prints debugging information. The *-o* option specifies the output file (default is stdout).
+
+
+[[example]]
+== EXAMPLE
+
+
+----
+
+$ g-scad -o model.scad model.g all.g
+$ openscad model.scad
+----
+
+
+[[see_also]]
+== SEE ALSO
+
+*csg-g*(1), *g-stl*(1), *openscad*(1)
+
+
+[[author]]
+== AUTHOR
+
+BRL-CAD Team
+
+
+[[copyright]]
+== COPYRIGHT
+
+This software is Copyright (c) 2025 by the United States Government as represented by U.S. Army Research Laboratory.
+
+
+[[bug_reports]]
+== BUG REPORTS
+
+Reports of bugs or problems should be submitted via electronic mail to devs@brlcad.org

--- a/src/conv/CMakeLists.txt
+++ b/src/conv/CMakeLists.txt
@@ -31,6 +31,8 @@ brlcad_addexec(comgeom-g "${comgeom-g_SRCS}" "libwdb;libbn;libbu;${M_LIBRARY}" F
 
 brlcad_addexec(conv-vg2g conv-vg2g.c "libbu" FOLDER Conv)
 
+brlcad_addexec(csg-g csg/csg-g.c "libwdb;librt;libbu" FOLDER Conv)
+
 brlcad_addexec(dbupgrade dbupgrade.c "libwdb;librt;libbu" FOLDER Conv)
 
 brlcad_addexec(dxf-g dxf/dxf-g.c "libwdb;librt;libnmg;libbn;libbu;${M_LIBRARY}" FOLDER Conv)

--- a/src/conv/CMakeLists.txt
+++ b/src/conv/CMakeLists.txt
@@ -33,6 +33,8 @@ brlcad_addexec(conv-vg2g conv-vg2g.c "libbu" FOLDER Conv)
 
 brlcad_addexec(csg-g csg/csg-g.c "libwdb;librt;libbu" FOLDER Conv)
 
+brlcad_addexec(g-scad csg/g-scad.c "libwdb;librt;libnmg;libbu" FOLDER Conv)
+
 brlcad_addexec(dbupgrade dbupgrade.c "libwdb;librt;libbu" FOLDER Conv)
 
 brlcad_addexec(dxf-g dxf/dxf-g.c "libwdb;librt;libnmg;libbn;libbu;${M_LIBRARY}" FOLDER Conv)

--- a/src/conv/csg/csg-g.c
+++ b/src/conv/csg/csg-g.c
@@ -1212,6 +1212,358 @@ done:
 
 
 /*
+ * Parse a circle node: circle($fn=N, $fa=N, $fs=N, r=R)
+ * Only meaningful as a child of rotate_extrude or linear_extrude.
+ * Stores radius in *r_out and returns 1 if found.
+ */
+static int
+parse_circle_2d(double *r_out)
+{
+    skip_ws();
+    if (!expect_char('('))
+	return 0;
+
+    find_param_double("r", r_out);
+
+    while (pos < buf_len && buf[pos] != ')')
+	pos++;
+    if (pos < buf_len) pos++;
+
+    skip_ws();
+    if (pos < buf_len && buf[pos] == ';')
+	pos++;
+
+    return 1;
+}
+
+
+/*
+ * Parse a square node: square(size=[x,y], center=false)
+ * Stores dimensions in size_out and centered flag.
+ */
+static int
+parse_square_2d(double size_out[2], int *centered)
+{
+    size_out[0] = 1.0;
+    size_out[1] = 1.0;
+    *centered = 0;
+
+    skip_ws();
+    if (!expect_char('('))
+	return 0;
+
+    find_param_array("size", size_out, 2, NULL);
+    find_param_bool("center", centered);
+
+    while (pos < buf_len && buf[pos] != ')')
+	pos++;
+    if (pos < buf_len) pos++;
+
+    skip_ws();
+    if (pos < buf_len && buf[pos] == ';')
+	pos++;
+
+    return 1;
+}
+
+
+/*
+ * Parse rotate_extrude() { child }
+ *
+ * The common pattern from BRL-CAD torus export is:
+ *   rotate_extrude(angle=360, ...) {
+ *     multmatrix([[1,0,0,R_major],...]) {  // translate([R_major,0,0])
+ *       circle(r=R_minor);
+ *     }
+ *   }
+ *
+ * This maps directly to mk_tor().
+ */
+static int
+parse_rotate_extrude(struct bu_vls *out_name, mat_t xform)
+{
+    struct bu_vls sname = BU_VLS_INIT_ZERO;
+    double angle = 360.0;
+    double circle_r = 0;
+    double major_r = 0;
+
+    skip_ws();
+    if (!expect_char('('))
+	return 0;
+
+    find_param_double("angle", &angle);
+
+    while (pos < buf_len && buf[pos] != ')')
+	pos++;
+    if (pos < buf_len) pos++;
+
+    skip_ws();
+    if (!expect_char('{'))
+	return 0;
+
+    /*
+     * Try to match the torus pattern:
+     *   multmatrix(translate) { circle(r) }
+     * or just: circle(r) with major_r = 0
+     */
+    skip_ws();
+
+    if (looking_at("multmatrix")) {
+	/* Parse the multmatrix to get the translation (major radius) */
+	double vals[16];
+	int i;
+
+	consume("multmatrix");
+	skip_ws();
+	if (!expect_char('('))
+	    goto fallback;
+	skip_ws();
+	if (!expect_char('['))
+	    goto fallback;
+
+	for (i = 0; i < 4; i++) {
+	    skip_ws();
+	    if (i > 0) { skip_ws(); if (pos < buf_len && buf[pos] == ',') pos++; }
+	    skip_ws();
+	    if (!expect_char('['))
+		goto fallback;
+	    vals[i*4+0] = parse_double(); skip_ws(); expect_char(',');
+	    vals[i*4+1] = parse_double(); skip_ws(); expect_char(',');
+	    vals[i*4+2] = parse_double(); skip_ws(); expect_char(',');
+	    vals[i*4+3] = parse_double(); skip_ws();
+	    if (!expect_char(']'))
+		goto fallback;
+	}
+	skip_ws(); expect_char(']'); skip_ws(); expect_char(')');
+
+	/* The X translation is the major radius */
+	major_r = vals[3];  /* row 0, col 3 = tx */
+
+	skip_ws();
+	if (!expect_char('{'))
+	    goto fallback;
+
+	skip_ws();
+	if (looking_at("circle")) {
+	    consume("circle");
+	    if (!parse_circle_2d(&circle_r))
+		goto fallback;
+	}
+
+	skip_ws();
+	expect_char('}'); /* close multmatrix block */
+    } else if (looking_at("circle")) {
+	consume("circle");
+	if (!parse_circle_2d(&circle_r))
+	    goto fallback;
+    } else {
+	goto fallback;
+    }
+
+    skip_ws();
+    expect_char('}'); /* close rotate_extrude block */
+
+    if (circle_r <= 0 || (NEAR_EQUAL(angle, 360.0, 0.01) && major_r <= 0)) {
+	bu_log("WARNING: rotate_extrude with unsupported parameters, skipping\n");
+	return 0;
+    }
+
+    /* Create torus: center at origin, normal along Z, major_r, minor_r = circle_r */
+    {
+	point_t center;
+	vect_t normal;
+
+	VSET(center, 0.0, 0.0, 0.0);
+	VSET(normal, 0.0, 0.0, 1.0);
+
+	make_solid_name(&sname);
+
+	if (bn_mat_is_identity(xform)) {
+	    mk_tor(fd_out, bu_vls_cstr(&sname), center, normal, major_r, circle_r);
+	} else {
+	    struct bu_vls raw = BU_VLS_INIT_ZERO;
+	    struct wmember head;
+
+	    bu_vls_sprintf(&raw, "s.raw.%d", solid_count);
+	    mk_tor(fd_out, bu_vls_cstr(&raw), center, normal, major_r, circle_r);
+
+	    BU_LIST_INIT(&head.l);
+	    mk_addmember(bu_vls_cstr(&raw), &head.l, xform, WMOP_UNION);
+	    mk_lcomb(fd_out, bu_vls_cstr(&sname), &head, 0,
+		     (char *)NULL, (char *)NULL, (unsigned char *)NULL, 0);
+	    bu_vls_free(&raw);
+	}
+
+	if (debug)
+	    bu_log("  torus: %s R=%g r=%g\n", bu_vls_cstr(&sname), major_r, circle_r);
+
+	bu_vls_vlscat(out_name, &sname);
+	bu_vls_free(&sname);
+	return 1;
+    }
+
+fallback:
+    /* Can't match a known pattern — skip the rest */
+    bu_log("WARNING: rotate_extrude with unsupported child, skipping\n");
+    while (pos < buf_len && buf[pos] != '}')
+	pos++;
+    if (pos < buf_len) pos++;
+    bu_vls_free(&sname);
+    return 0;
+}
+
+
+/*
+ * Parse linear_extrude(height=H, ...) { child }
+ *
+ * Special cases:
+ *   linear_extrude { square(size=[x,y]) }  →  mk_rpp (box)
+ *   linear_extrude { circle(r=R) }         →  mk_tgc (cylinder)
+ *
+ * Other children are unsupported (warn and skip).
+ */
+static int
+parse_linear_extrude(struct bu_vls *out_name, mat_t xform)
+{
+    struct bu_vls sname = BU_VLS_INIT_ZERO;
+    double height = 1.0;
+    int centered = 0;
+    double scale_arr[2] = {1.0, 1.0};
+
+    skip_ws();
+    if (!expect_char('('))
+	return 0;
+
+    find_param_double("height", &height);
+    find_param_bool("center", &centered);
+    find_param_array("scale", scale_arr, 2, NULL);
+
+    while (pos < buf_len && buf[pos] != ')')
+	pos++;
+    if (pos < buf_len) pos++;
+
+    skip_ws();
+    if (!expect_char('{'))
+	return 0;
+
+    skip_ws();
+
+    if (looking_at("square")) {
+	double sq_size[2];
+	int sq_centered = 0;
+	point_t min_pt, max_pt;
+
+	consume("square");
+	if (!parse_square_2d(sq_size, &sq_centered))
+	    goto fallback;
+
+	skip_ws();
+	expect_char('}');
+
+	/* Build RPP */
+	if (sq_centered) {
+	    VSET(min_pt, -sq_size[0]/2.0, -sq_size[1]/2.0, centered ? -height/2.0 : 0.0);
+	    VSET(max_pt,  sq_size[0]/2.0,  sq_size[1]/2.0, centered ? height/2.0 : height);
+	} else {
+	    VSET(min_pt, 0.0, 0.0, centered ? -height/2.0 : 0.0);
+	    VSET(max_pt, sq_size[0], sq_size[1], centered ? height/2.0 : height);
+	}
+
+	make_solid_name(&sname);
+
+	if (bn_mat_is_identity(xform)) {
+	    mk_rpp(fd_out, bu_vls_cstr(&sname), min_pt, max_pt);
+	} else {
+	    struct bu_vls raw = BU_VLS_INIT_ZERO;
+	    struct wmember head;
+
+	    bu_vls_sprintf(&raw, "s.raw.%d", solid_count);
+	    mk_rpp(fd_out, bu_vls_cstr(&raw), min_pt, max_pt);
+
+	    BU_LIST_INIT(&head.l);
+	    mk_addmember(bu_vls_cstr(&raw), &head.l, xform, WMOP_UNION);
+	    mk_lcomb(fd_out, bu_vls_cstr(&sname), &head, 0,
+		     (char *)NULL, (char *)NULL, (unsigned char *)NULL, 0);
+	    bu_vls_free(&raw);
+	}
+
+	if (debug)
+	    bu_log("  linear_extrude(square): %s [%g, %g] h=%g\n",
+		   bu_vls_cstr(&sname), sq_size[0], sq_size[1], height);
+
+	bu_vls_vlscat(out_name, &sname);
+	bu_vls_free(&sname);
+	return 1;
+
+    } else if (looking_at("circle")) {
+	double r = 1.0;
+	point_t base;
+	vect_t hvec, avec, bvec, cvec, dvec;
+
+	consume("circle");
+	if (!parse_circle_2d(&r))
+	    goto fallback;
+
+	skip_ws();
+	expect_char('}');
+
+	double z0 = centered ? -height/2.0 : 0.0;
+
+	VSET(base, 0.0, 0.0, z0);
+	VSET(hvec, 0.0, 0.0, height);
+	VSET(avec, r, 0.0, 0.0);
+	VSET(bvec, 0.0, r, 0.0);
+	/* Scale affects top radius */
+	double r_top = r * scale_arr[0];
+	VSET(cvec, r_top, 0.0, 0.0);
+	VSET(dvec, 0.0, r_top, 0.0);
+
+	make_solid_name(&sname);
+
+	if (bn_mat_is_identity(xform)) {
+	    mk_tgc(fd_out, bu_vls_cstr(&sname), base, hvec,
+		    avec, bvec, cvec, dvec);
+	} else {
+	    struct bu_vls raw = BU_VLS_INIT_ZERO;
+	    struct wmember head;
+
+	    bu_vls_sprintf(&raw, "s.raw.%d", solid_count);
+	    mk_tgc(fd_out, bu_vls_cstr(&raw), base, hvec,
+		    avec, bvec, cvec, dvec);
+
+	    BU_LIST_INIT(&head.l);
+	    mk_addmember(bu_vls_cstr(&raw), &head.l, xform, WMOP_UNION);
+	    mk_lcomb(fd_out, bu_vls_cstr(&sname), &head, 0,
+		     (char *)NULL, (char *)NULL, (unsigned char *)NULL, 0);
+	    bu_vls_free(&raw);
+	}
+
+	if (debug)
+	    bu_log("  linear_extrude(circle): %s r=%g h=%g\n",
+		   bu_vls_cstr(&sname), r, height);
+
+	bu_vls_vlscat(out_name, &sname);
+	bu_vls_free(&sname);
+	return 1;
+    }
+
+fallback:
+    bu_log("WARNING: linear_extrude with unsupported child, skipping\n");
+    /* Skip to closing brace */
+    {
+	int depth = 1;
+	while (pos < buf_len && depth > 0) {
+	    if (buf[pos] == '{') depth++;
+	    else if (buf[pos] == '}') depth--;
+	    pos++;
+	}
+    }
+    bu_vls_free(&sname);
+    return 0;
+}
+
+
+/*
  * Skip an unrecognized node: consume identifier, params, and
  * optional { children } block.
  */
@@ -1382,12 +1734,18 @@ parse_node(struct bu_vls *out_name, mat_t xform)
 	consume("polyhedron");
 	return parse_polyhedron(out_name, xform);
     }
+    if (looking_at("rotate_extrude")) {
+	consume("rotate_extrude");
+	return parse_rotate_extrude(out_name, xform);
+    }
+    if (looking_at("linear_extrude")) {
+	consume("linear_extrude");
+	return parse_linear_extrude(out_name, xform);
+    }
 
     /* Unsupported nodes: warn and skip */
-    if (looking_at("linear_extrude") || looking_at("rotate_extrude") ||
-	looking_at("hull") || looking_at("minkowski") ||
+    if (looking_at("hull") || looking_at("minkowski") ||
 	looking_at("polygon") ||
-	looking_at("square") || looking_at("circle") ||
 	looking_at("render") || looking_at("import")) {
 	size_t start = pos;
 	size_t end = pos;

--- a/src/conv/csg/csg-g.c
+++ b/src/conv/csg/csg-g.c
@@ -682,6 +682,70 @@ parse_cylinder(struct bu_vls *out_name, mat_t xform)
 
 
 /*
+ * Test whether a polyhedron is convex.  For each face, compute the
+ * plane normal from the first three vertices, then verify every
+ * other vertex lies on the same side of that plane.  The winding
+ * order (and thus normal direction) is not assumed — we just check
+ * that all non-face vertices agree on which side they are on.
+ *
+ * Returns 1 if convex, 0 if not.
+ */
+static int
+poly_is_convex(double verts[][3], int nv,
+	       int faces[][MAX_FACE_VERTS], int face_sizes[], int nf)
+{
+    int f, v;
+    double tol_dist = 1.0e-6;
+
+    for (f = 0; f < nf; f++) {
+	vect_t e1, e2, normal;
+	double d;
+	int v0, v1, v2;
+	int sign = 0; /* 0=unknown, 1=positive side, -1=negative side */
+
+	if (face_sizes[f] < 3)
+	    return 0;
+
+	v0 = faces[f][0];
+	v1 = faces[f][1];
+	v2 = faces[f][2];
+
+	VSUB2(e1, verts[v1], verts[v0]);
+	VSUB2(e2, verts[v2], verts[v0]);
+	VCROSS(normal, e1, e2);
+
+	/* Plane equation: normal . X = d */
+	d = VDOT(normal, verts[v0]);
+
+	/* All non-face vertices must be on the same side of this plane */
+	for (v = 0; v < nv; v++) {
+	    double dist;
+	    int on_face = 0;
+	    int k;
+	    for (k = 0; k < face_sizes[f]; k++) {
+		if (faces[f][k] == v) {
+		    on_face = 1;
+		    break;
+		}
+	    }
+	    if (on_face)
+		continue;
+
+	    dist = VDOT(normal, verts[v]) - d;
+	    if (dist > tol_dist) {
+		if (sign < 0) return 0;
+		sign = 1;
+	    } else if (dist < -tol_dist) {
+		if (sign > 0) return 0;
+		sign = -1;
+	    }
+	}
+    }
+    return 1;
+}
+
+
+/*
  * Try to match a polyhedron to an ARB8.  The polyhedron must have
  * exactly 8 vertices and 6 quadrilateral faces.  We find two
  * opposing quad faces and order the vertices so that face 0
@@ -1051,7 +1115,35 @@ parse_polyhedron(struct bu_vls *out_name, mat_t xform)
 
     make_solid_name(&sname);
 
-    /* Try ARB types in order of preference */
+    /* arb4 is always convex; try it first without a convexity check */
+    if (try_arb4(verts, nv, faces, face_sizes, nf, arb_pts)) {
+	if (debug)
+	    bu_log("  polyhedron: %s matched arb4 (%d verts, %d faces)\n",
+		   bu_vls_cstr(&sname), nv, nf);
+	if (bn_mat_is_identity(xform)) {
+	    mk_arb4(fd_out, bu_vls_cstr(&sname), arb_pts);
+	} else {
+	    struct bu_vls raw = BU_VLS_INIT_ZERO;
+	    struct wmember head;
+	    bu_vls_sprintf(&raw, "s.raw.%d", solid_count);
+	    mk_arb4(fd_out, bu_vls_cstr(&raw), arb_pts);
+	    BU_LIST_INIT(&head.l);
+	    mk_addmember(bu_vls_cstr(&raw), &head.l, xform, WMOP_UNION);
+	    mk_lcomb(fd_out, bu_vls_cstr(&sname), &head, 0,
+		     (char *)NULL, (char *)NULL, (unsigned char *)NULL, 0);
+	    bu_vls_free(&raw);
+	}
+	goto done;
+    }
+
+    /* Remaining ARB types require convexity */
+    if (!poly_is_convex(verts, nv, faces, face_sizes, nf)) {
+	if (debug)
+	    bu_log("  polyhedron: %s is non-convex, using bot (%d verts, %d faces)\n",
+		   bu_vls_cstr(&sname), nv, nf);
+	goto use_bot;
+    }
+
     if (try_arb8(verts, nv, faces, face_sizes, nf, arb_pts)) {
 	if (debug)
 	    bu_log("  polyhedron: %s matched arb8 (%d verts, %d faces)\n",
@@ -1086,24 +1178,8 @@ parse_polyhedron(struct bu_vls *out_name, mat_t xform)
 		     (char *)NULL, (char *)NULL, (unsigned char *)NULL, 0);
 	    bu_vls_free(&raw);
 	}
-    } else if (try_arb4(verts, nv, faces, face_sizes, nf, arb_pts)) {
-	if (debug)
-	    bu_log("  polyhedron: %s matched arb4 (%d verts, %d faces)\n",
-		   bu_vls_cstr(&sname), nv, nf);
-	if (bn_mat_is_identity(xform)) {
-	    mk_arb4(fd_out, bu_vls_cstr(&sname), arb_pts);
-	} else {
-	    struct bu_vls raw = BU_VLS_INIT_ZERO;
-	    struct wmember head;
-	    bu_vls_sprintf(&raw, "s.raw.%d", solid_count);
-	    mk_arb4(fd_out, bu_vls_cstr(&raw), arb_pts);
-	    BU_LIST_INIT(&head.l);
-	    mk_addmember(bu_vls_cstr(&raw), &head.l, xform, WMOP_UNION);
-	    mk_lcomb(fd_out, bu_vls_cstr(&sname), &head, 0,
-		     (char *)NULL, (char *)NULL, (unsigned char *)NULL, 0);
-	    bu_vls_free(&raw);
-	}
     } else {
+    use_bot:
 	/* Fall back to BOT */
 	if (debug)
 	    bu_log("  polyhedron: %s as bot (%d verts, %d faces)\n",
@@ -1123,6 +1199,7 @@ parse_polyhedron(struct bu_vls *out_name, mat_t xform)
 	}
     }
 
+done:
     bu_vls_vlscat(out_name, &sname);
     bu_vls_free(&sname);
 

--- a/src/conv/csg/csg-g.c
+++ b/src/conv/csg/csg-g.c
@@ -43,6 +43,7 @@
 #include "bu/getopt.h"
 #include "bu/log.h"
 #include "bu/malloc.h"
+#include "bu/path.h"
 #include "bu/str.h"
 #include "bu/vls.h"
 #include "vmath.h"
@@ -1771,6 +1772,181 @@ fallback:
 
 
 /*
+ * Parse an import() node by reading the referenced file (STL/OFF)
+ * and creating a BOT.  The file is resolved relative to the input
+ * .csg file's directory.
+ *
+ * Format: import(file = "foo.stl", layer = "", ...)
+ */
+static int
+parse_import(struct bu_vls *out_name, mat_t xform)
+{
+    struct bu_vls sname = BU_VLS_INIT_ZERO;
+    struct bu_vls filepath = BU_VLS_INIT_ZERO;
+    struct bu_vls filename = BU_VLS_INIT_ZERO;
+    size_t save_pos;
+    FILE *stl_fp;
+
+    skip_ws();
+    if (!expect_char('('))
+	return 0;
+
+    /* Find file = "..." parameter */
+    save_pos = pos;
+    while (pos < buf_len && buf[pos] != ')') {
+	skip_ws();
+	if (pos + 4 < buf_len && bu_strncmp(&buf[pos], "file", 4) == 0) {
+	    size_t p = pos + 4;
+	    while (p < buf_len && isspace((int)buf[p])) p++;
+	    if (p < buf_len && buf[p] == '=') {
+		p++;
+		while (p < buf_len && isspace((int)buf[p])) p++;
+		if (p < buf_len && buf[p] == '"') {
+		    size_t start;
+		    p++;
+		    start = p;
+		    while (p < buf_len && buf[p] != '"')
+			p++;
+		    bu_vls_strncpy(&filename, &buf[start], p - start);
+		    break;
+		}
+	    }
+	}
+	pos++;
+    }
+
+    /* Skip to end of params */
+    pos = save_pos;
+    while (pos < buf_len && buf[pos] != ')')
+	pos++;
+    if (pos < buf_len) pos++;
+
+    skip_ws();
+    if (pos < buf_len && buf[pos] == ';')
+	pos++;
+
+    if (bu_vls_strlen(&filename) == 0) {
+	bu_log("WARNING: import() with no file parameter, skipping\n");
+	bu_vls_free(&filename);
+	bu_vls_free(&filepath);
+	return 0;
+    }
+
+    /* Resolve path relative to input file directory */
+    {
+	struct bu_vls input_dir = BU_VLS_INIT_ZERO;
+	char *slash = strrchr(input_file, '/');
+	if (slash) {
+	    bu_vls_strncpy(&input_dir, input_file, slash - input_file + 1);
+	}
+	bu_vls_vlscat(&filepath, &input_dir);
+	bu_vls_vlscat(&filepath, &filename);
+	bu_vls_free(&input_dir);
+    }
+
+    /* Try the resolved path, then the filename as-is */
+    stl_fp = fopen(bu_vls_cstr(&filepath), "r");
+    if (!stl_fp)
+	stl_fp = fopen(bu_vls_cstr(&filename), "r");
+    if (!stl_fp) {
+	bu_log("WARNING: import() cannot open '%s', skipping\n",
+	       bu_vls_cstr(&filepath));
+	bu_vls_free(&filename);
+	bu_vls_free(&filepath);
+	return 0;
+    }
+
+    /* Read ASCII STL */
+    {
+	char line[512];
+	fastf_t *verts = NULL;
+	int *faces = NULL;
+	int nv = 0, nf = 0;
+	int verts_alloc = 0, faces_alloc = 0;
+	int tri_vi = 0;
+
+	while (bu_fgets(line, sizeof(line), stl_fp)) {
+	    char *p = line;
+	    while (*p && isspace((int)*p)) p++;
+
+	    if (bu_strncmp(p, "vertex", 6) == 0) {
+		double x, y, z;
+		if (sscanf(p + 6, "%lf %lf %lf", &x, &y, &z) == 3) {
+		    if (nv >= verts_alloc) {
+			verts_alloc = verts_alloc ? verts_alloc * 2 : 256;
+			verts = (fastf_t *)bu_realloc(verts,
+				    verts_alloc * 3 * sizeof(fastf_t), "stl verts");
+		    }
+		    verts[nv*3+0] = x;
+		    verts[nv*3+1] = y;
+		    verts[nv*3+2] = z;
+		    tri_vi++;
+		    nv++;
+
+		    if (tri_vi == 3) {
+			if (nf >= faces_alloc) {
+			    faces_alloc = faces_alloc ? faces_alloc * 2 : 256;
+			    faces = (int *)bu_realloc(faces,
+					faces_alloc * 3 * sizeof(int), "stl faces");
+			}
+			faces[nf*3+0] = nv - 3;
+			faces[nf*3+1] = nv - 2;
+			faces[nf*3+2] = nv - 1;
+			nf++;
+			tri_vi = 0;
+		    }
+		}
+	    }
+	}
+	fclose(stl_fp);
+
+	if (nv == 0 || nf == 0) {
+	    bu_log("WARNING: import() read 0 triangles from '%s', skipping\n",
+		   bu_vls_cstr(&filename));
+	    if (verts) bu_free(verts, "stl verts");
+	    if (faces) bu_free(faces, "stl faces");
+	    bu_vls_free(&filename);
+	    bu_vls_free(&filepath);
+	    return 0;
+	}
+
+	make_solid_name(&sname);
+
+	if (bn_mat_is_identity(xform)) {
+	    mk_bot(fd_out, bu_vls_cstr(&sname), RT_BOT_SOLID,
+		   RT_BOT_UNORIENTED, 0, nv, nf, verts, faces, NULL, NULL);
+	} else {
+	    struct bu_vls raw = BU_VLS_INIT_ZERO;
+	    struct wmember head;
+
+	    bu_vls_sprintf(&raw, "s.raw.%d", solid_count);
+	    mk_bot(fd_out, bu_vls_cstr(&raw), RT_BOT_SOLID,
+		   RT_BOT_UNORIENTED, 0, nv, nf, verts, faces, NULL, NULL);
+
+	    BU_LIST_INIT(&head.l);
+	    mk_addmember(bu_vls_cstr(&raw), &head.l, xform, WMOP_UNION);
+	    mk_lcomb(fd_out, bu_vls_cstr(&sname), &head, 0,
+		     (char *)NULL, (char *)NULL, (unsigned char *)NULL, 0);
+	    bu_vls_free(&raw);
+	}
+
+	if (debug)
+	    bu_log("  import(%s): %s (%d verts, %d faces)\n",
+		   bu_vls_cstr(&filename), bu_vls_cstr(&sname), nv, nf);
+
+	bu_free(verts, "stl verts");
+	bu_free(faces, "stl faces");
+    }
+
+    bu_vls_vlscat(out_name, &sname);
+    bu_vls_free(&sname);
+    bu_vls_free(&filename);
+    bu_vls_free(&filepath);
+    return 1;
+}
+
+
+/*
  * Skip an unrecognized node: consume identifier, params, and
  * optional { children } block.
  */
@@ -1950,10 +2126,29 @@ parse_node(struct bu_vls *out_name, mat_t xform)
 	return parse_linear_extrude(out_name, xform);
     }
 
+    if (looking_at("import")) {
+	consume("import");
+	return parse_import(out_name, xform);
+    }
+    if (looking_at("render")) {
+	/* render() is just a wrapper — pass through to child */
+	consume("render");
+	skip_params();
+	skip_ws();
+	if (!expect_char('{'))
+	    return 0;
+	skip_ws();
+	if (!parse_node(out_name, xform)) {
+	    while (pos < buf_len && buf[pos] != '}')
+		pos++;
+	}
+	expect_char('}');
+	return (bu_vls_strlen(out_name) > 0) ? 1 : 0;
+    }
+
     /* Unsupported nodes: warn and skip */
     if (looking_at("hull") || looking_at("minkowski") ||
-	looking_at("polygon") ||
-	looking_at("render") || looking_at("import")) {
+	looking_at("polygon")) {
 	size_t start = pos;
 	size_t end = pos;
 	while (end < buf_len && buf[end] != '(' && !isspace((int)buf[end]))

--- a/src/conv/csg/csg-g.c
+++ b/src/conv/csg/csg-g.c
@@ -1,0 +1,945 @@
+/*                         C S G - G . C
+ * BRL-CAD
+ *
+ * Copyright (c) 2025 United States Government as represented by
+ * the U.S. Army Research Laboratory.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this file; see the file named COPYING for more
+ * information.
+ *
+ */
+/** @file csg-g.c
+ *
+ * Convert OpenSCAD .csg format files to BRL-CAD .g binary format.
+ *
+ * The .csg format is OpenSCAD's evaluated CSG tree output, produced
+ * by running: openscad -o file.csg input.scad
+ *
+ * All variables, modules, loops, and conditionals are already resolved
+ * in this format, leaving only primitives, boolean operations, and
+ * transformations.
+ *
+ */
+
+#include "common.h"
+
+#include <stdlib.h>
+#include <math.h>
+#include <string.h>
+#include <ctype.h>
+#include <errno.h>
+
+#include "bu/app.h"
+#include "bu/getopt.h"
+#include "bu/log.h"
+#include "bu/malloc.h"
+#include "bu/str.h"
+#include "bu/vls.h"
+#include "vmath.h"
+#include "rt/geom.h"
+#include "raytrace.h"
+#include "wdb.h"
+
+
+static char *input_file;	/* name of the input file */
+static char *brlcad_file;	/* name of output file */
+static FILE *fd_in;		/* input file */
+static struct rt_wdb *fd_out;	/* output BRL-CAD file */
+static int debug = 0;		/* debug flag */
+static int solid_count = 0;	/* count of solids converted */
+static int comb_count = 0;	/* count of combinations created */
+static struct wmember all_head;	/* top-level group */
+
+/* Input buffer */
+static char *buf = NULL;	/* file contents */
+static size_t buf_len = 0;	/* buffer length */
+static size_t pos = 0;		/* current parse position */
+
+
+/*
+ * Generate a unique solid name like s.1, s.2, ...
+ */
+static void
+make_solid_name(struct bu_vls *name)
+{
+    bu_vls_sprintf(name, "s.%d", ++solid_count);
+}
+
+
+/*
+ * Generate a unique combination name like c.1, c.2, ...
+ */
+static void
+make_comb_name(struct bu_vls *name)
+{
+    bu_vls_sprintf(name, "c.%d", ++comb_count);
+}
+
+
+/*
+ * Skip whitespace and comments in the input buffer.
+ */
+static void
+skip_ws(void)
+{
+    while (pos < buf_len) {
+	if (isspace((int)buf[pos])) {
+	    pos++;
+	} else if (pos + 1 < buf_len && buf[pos] == '/' && buf[pos+1] == '/') {
+	    /* line comment */
+	    while (pos < buf_len && buf[pos] != '\n')
+		pos++;
+	} else if (pos + 1 < buf_len && buf[pos] == '/' && buf[pos+1] == '*') {
+	    /* block comment */
+	    pos += 2;
+	    while (pos + 1 < buf_len && !(buf[pos] == '*' && buf[pos+1] == '/'))
+		pos++;
+	    if (pos + 1 < buf_len)
+		pos += 2;
+	} else {
+	    break;
+	}
+    }
+}
+
+
+/*
+ * Check if the current position matches a keyword, followed by '(' or '{'.
+ * Does not advance the position.
+ */
+static int
+looking_at(const char *kw)
+{
+    size_t len = strlen(kw);
+    if (pos + len > buf_len)
+	return 0;
+    if (bu_strncmp(&buf[pos], kw, len) != 0)
+	return 0;
+    /* keyword must be followed by '(' or whitespace then '(' */
+    size_t p = pos + len;
+    while (p < buf_len && isspace((int)buf[p]))
+	p++;
+    if (p < buf_len && buf[p] == '(')
+	return 1;
+    return 0;
+}
+
+
+/*
+ * Consume a keyword and advance past it.
+ */
+static void
+consume(const char *kw)
+{
+    pos += strlen(kw);
+}
+
+
+/*
+ * Expect and consume a specific character.
+ */
+static int
+expect_char(char c)
+{
+    skip_ws();
+    if (pos < buf_len && buf[pos] == c) {
+	pos++;
+	return 1;
+    }
+    bu_log("csg-g: expected '%c' at position %zu, got '%c'\n",
+	   c, pos, (pos < buf_len) ? buf[pos] : '?');
+    return 0;
+}
+
+
+/*
+ * Parse a floating point number from the buffer.
+ */
+static double
+parse_double(void)
+{
+    skip_ws();
+    char *end;
+    double val = strtod(&buf[pos], &end);
+    pos = end - buf;
+    return val;
+}
+
+
+/*
+ * Look for a named parameter in the parameter list.
+ * Returns 1 and sets *val if found, 0 otherwise.
+ * Call before consuming the parameter list.
+ */
+static int
+find_param_double(const char *name, double *val)
+{
+    size_t save = pos;
+    size_t namelen = strlen(name);
+
+    while (pos < buf_len && buf[pos] != ')') {
+	skip_ws();
+	if (pos + namelen < buf_len && bu_strncmp(&buf[pos], name, namelen) == 0) {
+	    size_t p = pos + namelen;
+	    while (p < buf_len && isspace((int)buf[p])) p++;
+	    if (p < buf_len && buf[p] == '=') {
+		p++;
+		pos = p;
+		*val = parse_double();
+		pos = save;
+		return 1;
+	    }
+	}
+	/* advance to next comma or end */
+	while (pos < buf_len && buf[pos] != ',' && buf[pos] != ')')
+	    pos++;
+	if (pos < buf_len && buf[pos] == ',')
+	    pos++;
+    }
+    pos = save;
+    return 0;
+}
+
+
+/*
+ * Look for a named array parameter like size = [x, y, z].
+ * Returns 1 and fills vals (up to maxn entries) if found.
+ */
+static int
+find_param_array(const char *name, double *vals, int maxn, int *countp)
+{
+    size_t save = pos;
+    size_t namelen = strlen(name);
+    int count = 0;
+
+    while (pos < buf_len && buf[pos] != ')') {
+	skip_ws();
+	if (pos + namelen < buf_len && bu_strncmp(&buf[pos], name, namelen) == 0) {
+	    size_t p = pos + namelen;
+	    while (p < buf_len && isspace((int)buf[p])) p++;
+	    if (p < buf_len && buf[p] == '=') {
+		p++;
+		while (p < buf_len && isspace((int)buf[p])) p++;
+		if (p < buf_len && buf[p] == '[') {
+		    p++;
+		    pos = p;
+		    while (count < maxn) {
+			skip_ws();
+			if (pos < buf_len && buf[pos] == ']')
+			    break;
+			vals[count++] = parse_double();
+			skip_ws();
+			if (pos < buf_len && buf[pos] == ',')
+			    pos++;
+		    }
+		    if (countp) *countp = count;
+		    pos = save;
+		    return 1;
+		}
+	    }
+	}
+	while (pos < buf_len && buf[pos] != ',' && buf[pos] != ')')
+	    pos++;
+	if (pos < buf_len && buf[pos] == ',')
+	    pos++;
+    }
+    pos = save;
+    return 0;
+}
+
+
+/*
+ * Look for a boolean parameter like center = true/false.
+ */
+static int
+find_param_bool(const char *name, int *val)
+{
+    size_t save = pos;
+    size_t namelen = strlen(name);
+
+    while (pos < buf_len && buf[pos] != ')') {
+	skip_ws();
+	if (pos + namelen < buf_len && bu_strncmp(&buf[pos], name, namelen) == 0) {
+	    size_t p = pos + namelen;
+	    while (p < buf_len && isspace((int)buf[p])) p++;
+	    if (p < buf_len && buf[p] == '=') {
+		p++;
+		while (p < buf_len && isspace((int)buf[p])) p++;
+		if (p + 4 <= buf_len && bu_strncmp(&buf[p], "true", 4) == 0) {
+		    *val = 1;
+		    pos = save;
+		    return 1;
+		} else if (p + 5 <= buf_len && bu_strncmp(&buf[p], "false", 5) == 0) {
+		    *val = 0;
+		    pos = save;
+		    return 1;
+		}
+	    }
+	}
+	while (pos < buf_len && buf[pos] != ',' && buf[pos] != ')')
+	    pos++;
+	if (pos < buf_len && buf[pos] == ',')
+	    pos++;
+    }
+    pos = save;
+    return 0;
+}
+
+
+/*
+ * Skip everything inside parentheses (the parameter list).
+ */
+static void
+skip_params(void)
+{
+    skip_ws();
+    if (pos < buf_len && buf[pos] == '(') {
+	int depth = 1;
+	pos++;
+	while (pos < buf_len && depth > 0) {
+	    if (buf[pos] == '(') depth++;
+	    else if (buf[pos] == ')') depth--;
+	    pos++;
+	}
+    }
+}
+
+
+/* Forward declaration */
+static int parse_node(struct bu_vls *out_name, mat_t xform);
+
+
+/*
+ * Parse the children inside a { } block, collecting their names and
+ * applying a boolean operation.  Returns the name of the resulting
+ * combination in out_name.
+ */
+static int
+parse_boolean(const char *op_name, int wmop, struct bu_vls *out_name, mat_t parent_xform)
+{
+    struct wmember head;
+    struct bu_vls child_name = BU_VLS_INIT_ZERO;
+    struct bu_vls cname = BU_VLS_INIT_ZERO;
+    int child_count = 0;
+    int first = 1;
+
+    BU_LIST_INIT(&head.l);
+
+    skip_params();
+    skip_ws();
+
+    if (!expect_char('{'))
+	return 0;
+
+    while (1) {
+	skip_ws();
+	if (pos >= buf_len || buf[pos] == '}')
+	    break;
+
+	bu_vls_trunc(&child_name, 0);
+	if (parse_node(&child_name, parent_xform)) {
+	    int op;
+	    if (first) {
+		op = WMOP_UNION;
+		first = 0;
+	    } else {
+		op = wmop;
+	    }
+	    mk_addmember(bu_vls_cstr(&child_name), &head.l, NULL, op);
+	    child_count++;
+	}
+    }
+
+    expect_char('}');
+
+    if (child_count == 0) {
+	bu_vls_free(&child_name);
+	bu_vls_free(&cname);
+	return 0;
+    }
+
+    /* If only one child in a group/union, just pass through its name */
+    if (child_count == 1 && wmop == WMOP_UNION) {
+	bu_vls_vlscat(out_name, &child_name);
+	bu_vls_free(&child_name);
+	bu_vls_free(&cname);
+	return 1;
+    }
+
+    make_comb_name(&cname);
+    mk_lcomb(fd_out, bu_vls_cstr(&cname), &head, 0,
+	     (char *)NULL, (char *)NULL, (unsigned char *)NULL, 0);
+
+    if (debug)
+	bu_log("  %s: %s (%d children)\n", op_name, bu_vls_cstr(&cname), child_count);
+
+    bu_vls_vlscat(out_name, &cname);
+    bu_vls_free(&child_name);
+    bu_vls_free(&cname);
+    return 1;
+}
+
+
+/*
+ * Parse a multmatrix node.  The matrix is a 4x4 array of doubles.
+ * Applies the matrix to the child node's transform.
+ */
+static int
+parse_multmatrix(struct bu_vls *out_name, mat_t parent_xform)
+{
+    mat_t local_mat;
+    mat_t combined;
+    double vals[16];
+    int i;
+
+    skip_ws();
+    if (!expect_char('('))
+	return 0;
+
+    /* Parse [[a,b,c,d],[e,f,g,h],[i,j,k,l],[m,n,o,p]] */
+    skip_ws();
+    if (!expect_char('['))
+	return 0;
+
+    for (i = 0; i < 4; i++) {
+	skip_ws();
+	if (i > 0) {
+	    skip_ws();
+	    if (pos < buf_len && buf[pos] == ',')
+		pos++;
+	}
+	skip_ws();
+	if (!expect_char('['))
+	    return 0;
+	vals[i*4+0] = parse_double(); skip_ws(); expect_char(',');
+	vals[i*4+1] = parse_double(); skip_ws(); expect_char(',');
+	vals[i*4+2] = parse_double(); skip_ws(); expect_char(',');
+	vals[i*4+3] = parse_double(); skip_ws();
+	if (!expect_char(']'))
+	    return 0;
+    }
+
+    skip_ws();
+    expect_char(']');
+    skip_ws();
+    expect_char(')');
+
+    /*
+     * OpenSCAD uses row-major order:
+     *   [[r00, r01, r02, tx],
+     *    [r10, r11, r12, ty],
+     *    [r20, r21, r22, tz],
+     *    [  0,   0,   0,  1]]
+     *
+     * BRL-CAD uses a transposed column-major layout.
+     */
+    MAT_ZERO(local_mat);
+    local_mat[ 0] = vals[ 0]; local_mat[ 1] = vals[ 4]; local_mat[ 2] = vals[ 8]; local_mat[ 3] = vals[12];
+    local_mat[ 4] = vals[ 1]; local_mat[ 5] = vals[ 5]; local_mat[ 6] = vals[ 9]; local_mat[ 7] = vals[13];
+    local_mat[ 8] = vals[ 2]; local_mat[ 9] = vals[ 6]; local_mat[10] = vals[10]; local_mat[11] = vals[14];
+    local_mat[12] = vals[ 3]; local_mat[13] = vals[ 7]; local_mat[14] = vals[11]; local_mat[15] = vals[15];
+
+    bn_mat_mul(combined, parent_xform, local_mat);
+
+    skip_ws();
+    if (!expect_char('{'))
+	return 0;
+
+    /* Parse the single child */
+    skip_ws();
+    if (!parse_node(out_name, combined)) {
+	/* skip to closing brace */
+	while (pos < buf_len && buf[pos] != '}')
+	    pos++;
+    }
+
+    expect_char('}');
+    return (bu_vls_strlen(out_name) > 0) ? 1 : 0;
+}
+
+
+/*
+ * Parse a cube primitive: cube(size = [x, y, z], center = false)
+ */
+static int
+parse_cube(struct bu_vls *out_name, mat_t xform)
+{
+    struct bu_vls sname = BU_VLS_INIT_ZERO;
+    double size[3] = {1.0, 1.0, 1.0};
+    int centered = 0;
+    int n = 0;
+    point_t min_pt, max_pt;
+
+    skip_ws();
+    if (!expect_char('('))
+	return 0;
+
+    find_param_array("size", size, 3, &n);
+    find_param_bool("center", &centered);
+    skip_params(); /* consume rest - pos is past ')' since skip_params
+		    * was called but we already consumed '(' */
+
+    /* Rewind: skip_params expects to see '(' but we already consumed it.
+     * Instead, just skip to closing ')'. */
+    /* Actually, we need to skip to ')' */
+    while (pos < buf_len && buf[pos] != ')')
+	pos++;
+    if (pos < buf_len) pos++;
+
+    if (centered) {
+	VSET(min_pt, -size[0]/2.0, -size[1]/2.0, -size[2]/2.0);
+	VSET(max_pt,  size[0]/2.0,  size[1]/2.0,  size[2]/2.0);
+    } else {
+	VSET(min_pt, 0.0, 0.0, 0.0);
+	VSET(max_pt, size[0], size[1], size[2]);
+    }
+
+    /* Apply transform to the RPP by creating it with a matrix */
+    make_solid_name(&sname);
+
+    if (bn_mat_is_identity(xform)) {
+	mk_rpp(fd_out, bu_vls_cstr(&sname), min_pt, max_pt);
+    } else {
+	/* Create the RPP at identity, then wrap in a combination with the matrix */
+	struct bu_vls raw = BU_VLS_INIT_ZERO;
+	struct wmember head;
+
+	bu_vls_sprintf(&raw, "s.raw.%d", solid_count);
+	mk_rpp(fd_out, bu_vls_cstr(&raw), min_pt, max_pt);
+
+	BU_LIST_INIT(&head.l);
+	mk_addmember(bu_vls_cstr(&raw), &head.l, xform, WMOP_UNION);
+	mk_lcomb(fd_out, bu_vls_cstr(&sname), &head, 0,
+		 (char *)NULL, (char *)NULL, (unsigned char *)NULL, 0);
+	bu_vls_free(&raw);
+    }
+
+    if (debug)
+	bu_log("  cube: %s [%.3f, %.3f, %.3f]\n",
+	       bu_vls_cstr(&sname), size[0], size[1], size[2]);
+
+    bu_vls_vlscat(out_name, &sname);
+    bu_vls_free(&sname);
+
+    skip_ws();
+    if (pos < buf_len && buf[pos] == ';')
+	pos++;
+
+    return 1;
+}
+
+
+/*
+ * Parse a sphere primitive: sphere($fn = N, $fa = N, $fs = N, r = R)
+ */
+static int
+parse_sphere(struct bu_vls *out_name, mat_t xform)
+{
+    struct bu_vls sname = BU_VLS_INIT_ZERO;
+    double r = 1.0;
+    point_t center;
+
+    skip_ws();
+    if (!expect_char('('))
+	return 0;
+
+    find_param_double("r", &r);
+
+    while (pos < buf_len && buf[pos] != ')')
+	pos++;
+    if (pos < buf_len) pos++;
+
+    VSET(center, 0.0, 0.0, 0.0);
+
+    make_solid_name(&sname);
+
+    if (bn_mat_is_identity(xform)) {
+	mk_sph(fd_out, bu_vls_cstr(&sname), center, r);
+    } else {
+	struct bu_vls raw = BU_VLS_INIT_ZERO;
+	struct wmember head;
+
+	bu_vls_sprintf(&raw, "s.raw.%d", solid_count);
+	mk_sph(fd_out, bu_vls_cstr(&raw), center, r);
+
+	BU_LIST_INIT(&head.l);
+	mk_addmember(bu_vls_cstr(&raw), &head.l, xform, WMOP_UNION);
+	mk_lcomb(fd_out, bu_vls_cstr(&sname), &head, 0,
+		 (char *)NULL, (char *)NULL, (unsigned char *)NULL, 0);
+	bu_vls_free(&raw);
+    }
+
+    if (debug)
+	bu_log("  sphere: %s r=%.3f\n", bu_vls_cstr(&sname), r);
+
+    bu_vls_vlscat(out_name, &sname);
+    bu_vls_free(&sname);
+
+    skip_ws();
+    if (pos < buf_len && buf[pos] == ';')
+	pos++;
+
+    return 1;
+}
+
+
+/*
+ * Parse a cylinder primitive:
+ *   cylinder($fn=N, $fa=N, $fs=N, h=H, r1=R1, r2=R2, center=false)
+ */
+static int
+parse_cylinder(struct bu_vls *out_name, mat_t xform)
+{
+    struct bu_vls sname = BU_VLS_INIT_ZERO;
+    double h = 1.0, r1 = 1.0, r2 = 1.0;
+    int centered = 0;
+    point_t base;
+    vect_t height_vec, a_vec, b_vec;
+
+    skip_ws();
+    if (!expect_char('('))
+	return 0;
+
+    find_param_double("h", &h);
+    find_param_double("r1", &r1);
+    find_param_double("r2", &r2);
+    find_param_bool("center", &centered);
+
+    while (pos < buf_len && buf[pos] != ')')
+	pos++;
+    if (pos < buf_len) pos++;
+
+    if (centered) {
+	VSET(base, 0.0, 0.0, -h/2.0);
+    } else {
+	VSET(base, 0.0, 0.0, 0.0);
+    }
+    VSET(height_vec, 0.0, 0.0, h);
+
+    make_solid_name(&sname);
+
+    if (bn_mat_is_identity(xform)) {
+	/* TGC: base, height, A, B, C, D vectors */
+	VSET(a_vec, r1, 0.0, 0.0);
+	VSET(b_vec, 0.0, r1, 0.0);
+	vect_t c_vec, d_vec;
+	VSET(c_vec, r2, 0.0, 0.0);
+	VSET(d_vec, 0.0, r2, 0.0);
+	mk_tgc(fd_out, bu_vls_cstr(&sname), base, height_vec,
+		a_vec, b_vec, c_vec, d_vec);
+    } else {
+	struct bu_vls raw = BU_VLS_INIT_ZERO;
+	struct wmember head;
+	vect_t c_vec, d_vec;
+
+	bu_vls_sprintf(&raw, "s.raw.%d", solid_count);
+	VSET(a_vec, r1, 0.0, 0.0);
+	VSET(b_vec, 0.0, r1, 0.0);
+	VSET(c_vec, r2, 0.0, 0.0);
+	VSET(d_vec, 0.0, r2, 0.0);
+	mk_tgc(fd_out, bu_vls_cstr(&raw), base, height_vec,
+		a_vec, b_vec, c_vec, d_vec);
+
+	BU_LIST_INIT(&head.l);
+	mk_addmember(bu_vls_cstr(&raw), &head.l, xform, WMOP_UNION);
+	mk_lcomb(fd_out, bu_vls_cstr(&sname), &head, 0,
+		 (char *)NULL, (char *)NULL, (unsigned char *)NULL, 0);
+	bu_vls_free(&raw);
+    }
+
+    if (debug)
+	bu_log("  cylinder: %s h=%.3f r1=%.3f r2=%.3f\n",
+	       bu_vls_cstr(&sname), h, r1, r2);
+
+    bu_vls_vlscat(out_name, &sname);
+    bu_vls_free(&sname);
+
+    skip_ws();
+    if (pos < buf_len && buf[pos] == ';')
+	pos++;
+
+    return 1;
+}
+
+
+/*
+ * Skip an unrecognized node: consume identifier, params, and
+ * optional { children } block.
+ */
+static void
+skip_node(void)
+{
+    /* skip identifier */
+    while (pos < buf_len && !isspace((int)buf[pos]) && buf[pos] != '(' && buf[pos] != '{')
+	pos++;
+    skip_params();
+    skip_ws();
+    if (pos < buf_len && buf[pos] == '{') {
+	int depth = 1;
+	pos++;
+	while (pos < buf_len && depth > 0) {
+	    if (buf[pos] == '{') depth++;
+	    else if (buf[pos] == '}') depth--;
+	    pos++;
+	}
+    }
+    skip_ws();
+    if (pos < buf_len && buf[pos] == ';')
+	pos++;
+}
+
+
+/*
+ * Parse a color() wrapper: color([r, g, b, a]) { child }
+ * We currently ignore the color and just parse the child.
+ */
+static int
+parse_color(struct bu_vls *out_name, mat_t xform)
+{
+    skip_params();
+    skip_ws();
+    if (!expect_char('{'))
+	return 0;
+
+    skip_ws();
+    if (!parse_node(out_name, xform)) {
+	while (pos < buf_len && buf[pos] != '}')
+	    pos++;
+    }
+
+    expect_char('}');
+    return (bu_vls_strlen(out_name) > 0) ? 1 : 0;
+}
+
+
+/*
+ * Parse a single CSG node.  This is the main recursive dispatch.
+ * Returns the name of the created object in out_name.
+ */
+static int
+parse_node(struct bu_vls *out_name, mat_t xform)
+{
+    skip_ws();
+
+    if (pos >= buf_len)
+	return 0;
+
+    /* Boolean operations */
+    if (looking_at("difference")) {
+	consume("difference");
+	return parse_boolean("difference", WMOP_SUBTRACT, out_name, xform);
+    }
+    if (looking_at("union")) {
+	consume("union");
+	return parse_boolean("union", WMOP_UNION, out_name, xform);
+    }
+    if (looking_at("intersection")) {
+	consume("intersection");
+	return parse_boolean("intersection", WMOP_INTERSECT, out_name, xform);
+    }
+    if (looking_at("group")) {
+	consume("group");
+	return parse_boolean("group", WMOP_UNION, out_name, xform);
+    }
+
+    /* Transform */
+    if (looking_at("multmatrix")) {
+	consume("multmatrix");
+	return parse_multmatrix(out_name, xform);
+    }
+
+    /* Color (pass through to child) */
+    if (looking_at("color")) {
+	consume("color");
+	return parse_color(out_name, xform);
+    }
+
+    /* Primitives */
+    if (looking_at("cube")) {
+	consume("cube");
+	return parse_cube(out_name, xform);
+    }
+    if (looking_at("sphere")) {
+	consume("sphere");
+	return parse_sphere(out_name, xform);
+    }
+    if (looking_at("cylinder")) {
+	consume("cylinder");
+	return parse_cylinder(out_name, xform);
+    }
+
+    /* Unsupported nodes: warn and skip */
+    if (looking_at("linear_extrude") || looking_at("rotate_extrude") ||
+	looking_at("hull") || looking_at("minkowski") ||
+	looking_at("polyhedron") || looking_at("polygon") ||
+	looking_at("square") || looking_at("circle") ||
+	looking_at("render") || looking_at("import")) {
+	size_t start = pos;
+	size_t end = pos;
+	while (end < buf_len && buf[end] != '(' && !isspace((int)buf[end]))
+	    end++;
+	bu_log("WARNING: unsupported node '%.*s' at position %zu, skipping\n",
+	       (int)(end - start), &buf[start], pos);
+	skip_node();
+	return 0;
+    }
+
+    /* Unknown node */
+    if (isalpha((int)buf[pos]) || buf[pos] == '_') {
+	size_t start = pos;
+	size_t end = pos;
+	while (end < buf_len && buf[end] != '(' && !isspace((int)buf[end]))
+	    end++;
+	if (debug)
+	    bu_log("  skipping unknown node '%.*s'\n",
+		   (int)(end - start), &buf[start]);
+	skip_node();
+	return 0;
+    }
+
+    /* If we get here, something unexpected */
+    bu_log("csg-g: unexpected character '%c' at position %zu\n",
+	   buf[pos], pos);
+    pos++;
+    return 0;
+}
+
+
+static void
+Convert_input(void)
+{
+    mat_t identity;
+
+    MAT_IDN(identity);
+
+    while (pos < buf_len) {
+	struct bu_vls name = BU_VLS_INIT_ZERO;
+
+	skip_ws();
+	if (pos >= buf_len)
+	    break;
+
+	if (parse_node(&name, identity)) {
+	    mk_addmember(bu_vls_cstr(&name), &all_head.l, NULL, WMOP_UNION);
+	}
+
+	bu_vls_free(&name);
+    }
+}
+
+
+static void
+usage(const char *argv0)
+{
+    bu_log("Usage: %s [-d] input.csg output.g\n", argv0);
+    bu_log("	where input.csg is an OpenSCAD CSG export file\n");
+    bu_log("	(produced by: openscad -o file.csg input.scad)\n");
+    bu_log("	and output.g is the name of a BRL-CAD database file to receive the conversion.\n");
+    bu_log("	The -d option prints additional debugging information.\n");
+}
+
+
+int
+main(int argc, char *argv[])
+{
+    int c;
+    long file_size;
+
+    bu_setprogname(argv[0]);
+
+    if (argc < 2) {
+	usage(argv[0]);
+	bu_exit(1, NULL);
+    }
+
+    while ((c = bu_getopt(argc, argv, "d")) != -1) {
+	switch (c) {
+	    case 'd':
+		debug = 1;
+		break;
+	    default:
+		usage(argv[0]);
+		bu_exit(1, NULL);
+		break;
+	}
+    }
+
+    if (bu_optind + 1 >= argc) {
+	usage(argv[0]);
+	bu_exit(1, "csg-g: need input and output file names\n");
+    }
+
+    input_file = argv[bu_optind];
+    brlcad_file = argv[bu_optind + 1];
+
+    /* Open input file and read entire contents */
+    if ((fd_in = fopen(input_file, "r")) == NULL) {
+	bu_log("Cannot open input file (%s)\n", input_file);
+	perror("csg-g");
+	bu_exit(1, NULL);
+    }
+
+    fseek(fd_in, 0, SEEK_END);
+    file_size = ftell(fd_in);
+    fseek(fd_in, 0, SEEK_SET);
+
+    buf = (char *)bu_malloc(file_size + 1, "input buffer");
+    if (fread(buf, 1, file_size, fd_in) != (size_t)file_size) {
+	bu_log("Error reading input file (%s)\n", input_file);
+	perror("csg-g");
+	bu_exit(1, NULL);
+    }
+    buf[file_size] = '\0';
+    buf_len = file_size;
+    fclose(fd_in);
+
+    /* Open output */
+    if ((fd_out = wdb_fopen(brlcad_file)) == NULL) {
+	bu_log("Cannot open BRL-CAD file (%s)\n", brlcad_file);
+	perror("csg-g");
+	bu_exit(1, NULL);
+    }
+
+    mk_id_units(fd_out, "Conversion from OpenSCAD CSG format", "mm");
+
+    BU_LIST_INIT(&all_head.l);
+
+    bu_log("Converting OpenSCAD CSG file: %s\n", input_file);
+
+    Convert_input();
+
+    /* Make a top level group */
+    if (BU_LIST_NON_EMPTY(&all_head.l)) {
+	mk_lcomb(fd_out, "all", &all_head, 0,
+		 (char *)NULL, (char *)NULL, (unsigned char *)NULL, 0);
+    }
+
+    bu_log("Conversion complete: %d solids, %d combinations\n",
+	   solid_count, comb_count);
+
+    bu_free(buf, "input buffer");
+    db_close(fd_out->dbip);
+
+    return 0;
+}
+
+
+/*
+ * Local Variables:
+ * mode: C
+ * tab-width: 8
+ * indent-tabs-mode: t
+ * c-file-style: "stroustrup"
+ * End:
+ * ex: shiftwidth=4 tabstop=8
+ */

--- a/src/conv/csg/csg-g.c
+++ b/src/conv/csg/csg-g.c
@@ -1240,12 +1240,43 @@ skip_node(void)
 
 /*
  * Parse a color() wrapper: color([r, g, b, a]) { child }
- * We currently ignore the color and just parse the child.
+ * Applies the color as attributes on the child object.
  */
 static int
 parse_color(struct bu_vls *out_name, mat_t xform)
 {
-    skip_params();
+    double rgba[4] = {-1, -1, -1, 1.0};
+    int n = 0;
+
+    skip_ws();
+    if (!expect_char('('))
+	return 0;
+
+    /* color params are just ([r, g, b, a]) — a bare array */
+    skip_ws();
+    if (pos < buf_len && buf[pos] == '[') {
+	pos++;
+	while (n < 4) {
+	    skip_ws();
+	    if (pos < buf_len && buf[pos] == ']')
+		break;
+	    if (n > 0) {
+		skip_ws();
+		if (pos < buf_len && buf[pos] == ',')
+		    pos++;
+	    }
+	    rgba[n++] = parse_double();
+	}
+	skip_ws();
+	if (pos < buf_len && buf[pos] == ']')
+	    pos++;
+    }
+
+    /* Skip to closing ')' */
+    while (pos < buf_len && buf[pos] != ')')
+	pos++;
+    if (pos < buf_len) pos++;
+
     skip_ws();
     if (!expect_char('{'))
 	return 0;
@@ -1257,6 +1288,37 @@ parse_color(struct bu_vls *out_name, mat_t xform)
     }
 
     expect_char('}');
+
+    /* Apply color attributes to the child object */
+    if (bu_vls_strlen(out_name) > 0 && rgba[0] >= 0) {
+	struct bu_vls colorstr = BU_VLS_INIT_ZERO;
+	int r = (int)(rgba[0] * 255.0 + 0.5);
+	int g = (int)(rgba[1] * 255.0 + 0.5);
+	int b = (int)(rgba[2] * 255.0 + 0.5);
+
+	if (r > 255) r = 255;
+	if (g > 255) g = 255;
+	if (b > 255) b = 255;
+
+	bu_vls_sprintf(&colorstr, "%d/%d/%d", r, g, b);
+	db5_update_attribute(bu_vls_cstr(out_name), "color",
+			     bu_vls_cstr(&colorstr), fd_out->dbip);
+
+	if (n >= 4 && rgba[3] < 1.0) {
+	    struct bu_vls alphastr = BU_VLS_INIT_ZERO;
+	    bu_vls_sprintf(&alphastr, "%.3f", rgba[3]);
+	    db5_update_attribute(bu_vls_cstr(out_name), "alpha",
+				bu_vls_cstr(&alphastr), fd_out->dbip);
+	    bu_vls_free(&alphastr);
+	}
+
+	if (debug)
+	    bu_log("  color: %s = %d/%d/%d\n",
+		   bu_vls_cstr(out_name), r, g, b);
+
+	bu_vls_free(&colorstr);
+    }
+
     return (bu_vls_strlen(out_name) > 0) ? 1 : 0;
 }
 

--- a/src/conv/csg/csg-g.c
+++ b/src/conv/csg/csg-g.c
@@ -673,6 +673,468 @@ parse_cylinder(struct bu_vls *out_name, mat_t xform)
 
 
 /*
+ * Maximum polyhedron size we handle for ARB detection.  Polyhedra
+ * with more vertices or faces go straight to BOT.
+ */
+#define MAX_POLY_VERTS 256
+#define MAX_POLY_FACES 256
+#define MAX_FACE_VERTS 8
+
+
+/*
+ * Try to match a polyhedron to an ARB8.  The polyhedron must have
+ * exactly 8 vertices and 6 quadrilateral faces.  We find two
+ * opposing quad faces and order the vertices so that face 0
+ * (bottom) has vertices 0-3 and face 1 (top) has vertices 4-7,
+ * with edges connecting 0-4, 1-5, 2-6, 3-7.
+ *
+ * Returns 1 on success with pts filled (8 points * 3 coords).
+ */
+static int
+try_arb8(double verts[][3], int nv,
+	 int faces[][MAX_FACE_VERTS], int face_sizes[], int nf,
+	 fastf_t *pts)
+{
+    int i, j, k;
+    int bot_face = -1, top_face = -1;
+    int bot_idx[4], top_idx[4];
+    int used_verts[8];
+
+    if (nv != 8 || nf != 6)
+	return 0;
+
+    /* All faces must be quads */
+    for (i = 0; i < 6; i++) {
+	if (face_sizes[i] != 4)
+	    return 0;
+    }
+
+    /*
+     * Find two opposing faces.  Two quad faces are "opposing" if
+     * they share no vertices.  Pick the first such pair.
+     */
+    for (i = 0; i < 6 && bot_face < 0; i++) {
+	for (j = i + 1; j < 6; j++) {
+	    int shared = 0;
+	    for (k = 0; k < 4 && !shared; k++) {
+		int m;
+		for (m = 0; m < 4; m++) {
+		    if (faces[i][k] == faces[j][m]) {
+			shared = 1;
+			break;
+		    }
+		}
+	    }
+	    if (!shared) {
+		bot_face = i;
+		top_face = j;
+		break;
+	    }
+	}
+    }
+
+    if (bot_face < 0)
+	return 0;
+
+    /* Copy bottom face vertex indices */
+    for (i = 0; i < 4; i++)
+	bot_idx[i] = faces[bot_face][i];
+
+    /*
+     * For each bottom vertex, find the connected top vertex.
+     * Two vertices are connected if they share an edge — i.e.,
+     * they appear together on one of the 4 side faces.
+     */
+    memset(used_verts, 0, sizeof(used_verts));
+    for (i = 0; i < 4; i++) {
+	int found = 0;
+	for (j = 0; j < 6 && !found; j++) {
+	    if (j == bot_face || j == top_face)
+		continue;
+	    /* Check if this side face contains bot_idx[i] */
+	    int has_bot = 0, bot_pos = -1;
+	    for (k = 0; k < face_sizes[j]; k++) {
+		if (faces[j][k] == bot_idx[i]) {
+		    has_bot = 1;
+		    bot_pos = k;
+		    break;
+		}
+	    }
+	    if (!has_bot)
+		continue;
+	    /* Find adjacent vertex on this face that is a top vertex */
+	    int prev = (bot_pos + face_sizes[j] - 1) % face_sizes[j];
+	    int next = (bot_pos + 1) % face_sizes[j];
+	    int candidates[2] = { faces[j][prev], faces[j][next] };
+	    int c;
+	    for (c = 0; c < 2; c++) {
+		int m;
+		for (m = 0; m < 4; m++) {
+		    if (candidates[c] == faces[top_face][m] && !used_verts[candidates[c]]) {
+			top_idx[i] = candidates[c];
+			used_verts[candidates[c]] = 1;
+			found = 1;
+			break;
+		    }
+		}
+		if (found) break;
+	    }
+	}
+	if (!found)
+	    return 0;
+    }
+
+    /* Fill pts array: bottom 0-3, top 4-7 */
+    for (i = 0; i < 4; i++) {
+	VMOVE(&pts[i*3], verts[bot_idx[i]]);
+    }
+    for (i = 0; i < 4; i++) {
+	VMOVE(&pts[(i+4)*3], verts[top_idx[i]]);
+    }
+
+    return 1;
+}
+
+
+/*
+ * Try to match a polyhedron to an ARB4 (tetrahedron).
+ * Must have 4 vertices and 4 triangular faces.
+ */
+static int
+try_arb4(double verts[][3], int nv,
+	 int UNUSED(faces[][MAX_FACE_VERTS]), int face_sizes[], int nf,
+	 fastf_t *pts)
+{
+    int i;
+
+    if (nv != 4 || nf != 4)
+	return 0;
+
+    for (i = 0; i < 4; i++) {
+	if (face_sizes[i] != 3)
+	    return 0;
+    }
+
+    for (i = 0; i < 4; i++) {
+	VMOVE(&pts[i*3], verts[i]);
+    }
+
+    return 1;
+}
+
+
+/*
+ * Try to match a polyhedron to an ARB5 (pyramid with quad base).
+ * Must have 5 vertices and 5 faces: 1 quad + 4 triangles.
+ */
+static int
+try_arb5(double verts[][3], int nv,
+	 int faces[][MAX_FACE_VERTS], int face_sizes[], int nf,
+	 fastf_t *pts)
+{
+    int i;
+    int quad_face = -1;
+    int apex = -1;
+    int on_quad[5] = {0, 0, 0, 0, 0};
+
+    if (nv != 5 || nf != 5)
+	return 0;
+
+    /* Find the single quad face */
+    for (i = 0; i < 5; i++) {
+	if (face_sizes[i] == 4) {
+	    if (quad_face >= 0) return 0; /* two quads */
+	    quad_face = i;
+	} else if (face_sizes[i] != 3) {
+	    return 0;
+	}
+    }
+    if (quad_face < 0)
+	return 0;
+
+    /* Mark vertices on the quad face */
+    for (i = 0; i < 4; i++)
+	on_quad[faces[quad_face][i]] = 1;
+
+    /* The apex is the vertex not on the quad face */
+    for (i = 0; i < 5; i++) {
+	if (!on_quad[i]) {
+	    apex = i;
+	    break;
+	}
+    }
+    if (apex < 0) return 0;
+
+    /* pts: base quad (0-3), then apex (4) */
+    for (i = 0; i < 4; i++)
+	VMOVE(&pts[i*3], verts[faces[quad_face][i]]);
+    VMOVE(&pts[4*3], verts[apex]);
+
+    return 1;
+}
+
+
+/*
+ * Create a BOT (Bag of Triangles) from a polyhedron.
+ * Triangulates any non-triangular faces using a simple fan.
+ */
+static void
+make_bot_from_poly(const char *name,
+		   double verts[][3], int nv,
+		   int faces[][MAX_FACE_VERTS], int face_sizes[], int nf)
+{
+    int i, j;
+    int tri_count = 0;
+    int *bot_faces_arr;
+    fastf_t *bot_verts;
+    int fi;
+
+    /* Count triangles after fan triangulation */
+    for (i = 0; i < nf; i++)
+	tri_count += face_sizes[i] - 2;
+
+    bot_verts = (fastf_t *)bu_calloc(nv * 3, sizeof(fastf_t), "bot verts");
+    bot_faces_arr = (int *)bu_calloc(tri_count * 3, sizeof(int), "bot faces");
+
+    for (i = 0; i < nv; i++) {
+	bot_verts[i*3+0] = verts[i][0];
+	bot_verts[i*3+1] = verts[i][1];
+	bot_verts[i*3+2] = verts[i][2];
+    }
+
+    fi = 0;
+    for (i = 0; i < nf; i++) {
+	/* Fan triangulation from first vertex of each face */
+	for (j = 1; j < face_sizes[i] - 1; j++) {
+	    bot_faces_arr[fi*3+0] = faces[i][0];
+	    bot_faces_arr[fi*3+1] = faces[i][j];
+	    bot_faces_arr[fi*3+2] = faces[i][j+1];
+	    fi++;
+	}
+    }
+
+    mk_bot(fd_out, name, RT_BOT_SOLID, RT_BOT_UNORIENTED, 0,
+	   nv, tri_count, bot_verts, bot_faces_arr, NULL, NULL);
+
+    bu_free(bot_verts, "bot verts");
+    bu_free(bot_faces_arr, "bot faces");
+}
+
+
+/*
+ * Parse a polyhedron:
+ *   polyhedron(points = [[x,y,z], ...], faces = [[i,j,k,...], ...], convexity = N)
+ *
+ * First tries to match ARB4/5/8.  Falls back to BOT.
+ */
+static int
+parse_polyhedron(struct bu_vls *out_name, mat_t xform)
+{
+    struct bu_vls sname = BU_VLS_INIT_ZERO;
+    double verts[MAX_POLY_VERTS][3];
+    int faces[MAX_POLY_FACES][MAX_FACE_VERTS];
+    int face_sizes[MAX_POLY_FACES];
+    int nv = 0, nf = 0;
+    size_t save_pos;
+    fastf_t arb_pts[8*3];
+
+    skip_ws();
+    if (!expect_char('('))
+	return 0;
+
+    /* We need to parse points and faces manually since they are
+     * nested arrays.  Save position and scan for each parameter.
+     */
+    save_pos = pos;
+
+    /* Find "points = [[...]]" */
+    while (pos < buf_len && buf[pos] != ')') {
+	skip_ws();
+	if (pos + 6 < buf_len && bu_strncmp(&buf[pos], "points", 6) == 0) {
+	    pos += 6;
+	    skip_ws();
+	    if (pos < buf_len && buf[pos] == '=') {
+		pos++;
+		skip_ws();
+		if (!expect_char('['))
+		    break;
+		while (nv < MAX_POLY_VERTS) {
+		    skip_ws();
+		    if (pos < buf_len && buf[pos] == ']')
+			break;
+		    if (nv > 0) {
+			skip_ws();
+			if (pos < buf_len && buf[pos] == ',')
+			    pos++;
+		    }
+		    skip_ws();
+		    if (!expect_char('['))
+			break;
+		    verts[nv][0] = parse_double(); skip_ws(); expect_char(',');
+		    verts[nv][1] = parse_double(); skip_ws(); expect_char(',');
+		    verts[nv][2] = parse_double(); skip_ws();
+		    if (!expect_char(']'))
+			break;
+		    nv++;
+		}
+		skip_ws();
+		if (pos < buf_len && buf[pos] == ']')
+		    pos++;
+	    }
+	    break;
+	}
+	pos++;
+    }
+
+    /* Find "faces = [[...]]" */
+    pos = save_pos;
+    while (pos < buf_len && buf[pos] != ')') {
+	skip_ws();
+	if (pos + 5 < buf_len && bu_strncmp(&buf[pos], "faces", 5) == 0) {
+	    size_t p = pos + 5;
+	    while (p < buf_len && isspace((int)buf[p])) p++;
+	    if (p < buf_len && buf[p] == '=') {
+		pos = p + 1;
+		skip_ws();
+		if (!expect_char('['))
+		    break;
+		while (nf < MAX_POLY_FACES) {
+		    int fv = 0;
+		    skip_ws();
+		    if (pos < buf_len && buf[pos] == ']')
+			break;
+		    if (nf > 0) {
+			skip_ws();
+			if (pos < buf_len && buf[pos] == ',')
+			    pos++;
+		    }
+		    skip_ws();
+		    if (!expect_char('['))
+			break;
+		    while (fv < MAX_FACE_VERTS) {
+			skip_ws();
+			if (pos < buf_len && buf[pos] == ']')
+			    break;
+			if (fv > 0) {
+			    skip_ws();
+			    if (pos < buf_len && buf[pos] == ',')
+				pos++;
+			}
+			double fval = parse_double();
+			faces[nf][fv] = (int)fval;
+			fv++;
+		    }
+		    face_sizes[nf] = fv;
+		    skip_ws();
+		    if (pos < buf_len && buf[pos] == ']')
+			pos++;
+		    nf++;
+		}
+		skip_ws();
+		if (pos < buf_len && buf[pos] == ']')
+		    pos++;
+	    }
+	    break;
+	}
+	pos++;
+    }
+
+    /* Skip to end of params */
+    while (pos < buf_len && buf[pos] != ')')
+	pos++;
+    if (pos < buf_len) pos++;
+
+    if (nv == 0 || nf == 0) {
+	bu_log("WARNING: polyhedron with no points or faces, skipping\n");
+	return 0;
+    }
+
+    make_solid_name(&sname);
+
+    /* Try ARB types in order of preference */
+    if (try_arb8(verts, nv, faces, face_sizes, nf, arb_pts)) {
+	if (debug)
+	    bu_log("  polyhedron: %s matched arb8 (%d verts, %d faces)\n",
+		   bu_vls_cstr(&sname), nv, nf);
+	if (bn_mat_is_identity(xform)) {
+	    mk_arb8(fd_out, bu_vls_cstr(&sname), arb_pts);
+	} else {
+	    struct bu_vls raw = BU_VLS_INIT_ZERO;
+	    struct wmember head;
+	    bu_vls_sprintf(&raw, "s.raw.%d", solid_count);
+	    mk_arb8(fd_out, bu_vls_cstr(&raw), arb_pts);
+	    BU_LIST_INIT(&head.l);
+	    mk_addmember(bu_vls_cstr(&raw), &head.l, xform, WMOP_UNION);
+	    mk_lcomb(fd_out, bu_vls_cstr(&sname), &head, 0,
+		     (char *)NULL, (char *)NULL, (unsigned char *)NULL, 0);
+	    bu_vls_free(&raw);
+	}
+    } else if (try_arb5(verts, nv, faces, face_sizes, nf, arb_pts)) {
+	if (debug)
+	    bu_log("  polyhedron: %s matched arb5 (%d verts, %d faces)\n",
+		   bu_vls_cstr(&sname), nv, nf);
+	if (bn_mat_is_identity(xform)) {
+	    mk_arb5(fd_out, bu_vls_cstr(&sname), arb_pts);
+	} else {
+	    struct bu_vls raw = BU_VLS_INIT_ZERO;
+	    struct wmember head;
+	    bu_vls_sprintf(&raw, "s.raw.%d", solid_count);
+	    mk_arb5(fd_out, bu_vls_cstr(&raw), arb_pts);
+	    BU_LIST_INIT(&head.l);
+	    mk_addmember(bu_vls_cstr(&raw), &head.l, xform, WMOP_UNION);
+	    mk_lcomb(fd_out, bu_vls_cstr(&sname), &head, 0,
+		     (char *)NULL, (char *)NULL, (unsigned char *)NULL, 0);
+	    bu_vls_free(&raw);
+	}
+    } else if (try_arb4(verts, nv, faces, face_sizes, nf, arb_pts)) {
+	if (debug)
+	    bu_log("  polyhedron: %s matched arb4 (%d verts, %d faces)\n",
+		   bu_vls_cstr(&sname), nv, nf);
+	if (bn_mat_is_identity(xform)) {
+	    mk_arb4(fd_out, bu_vls_cstr(&sname), arb_pts);
+	} else {
+	    struct bu_vls raw = BU_VLS_INIT_ZERO;
+	    struct wmember head;
+	    bu_vls_sprintf(&raw, "s.raw.%d", solid_count);
+	    mk_arb4(fd_out, bu_vls_cstr(&raw), arb_pts);
+	    BU_LIST_INIT(&head.l);
+	    mk_addmember(bu_vls_cstr(&raw), &head.l, xform, WMOP_UNION);
+	    mk_lcomb(fd_out, bu_vls_cstr(&sname), &head, 0,
+		     (char *)NULL, (char *)NULL, (unsigned char *)NULL, 0);
+	    bu_vls_free(&raw);
+	}
+    } else {
+	/* Fall back to BOT */
+	if (debug)
+	    bu_log("  polyhedron: %s as bot (%d verts, %d faces)\n",
+		   bu_vls_cstr(&sname), nv, nf);
+	if (bn_mat_is_identity(xform)) {
+	    make_bot_from_poly(bu_vls_cstr(&sname), verts, nv, faces, face_sizes, nf);
+	} else {
+	    struct bu_vls raw = BU_VLS_INIT_ZERO;
+	    struct wmember head;
+	    bu_vls_sprintf(&raw, "s.raw.%d", solid_count);
+	    make_bot_from_poly(bu_vls_cstr(&raw), verts, nv, faces, face_sizes, nf);
+	    BU_LIST_INIT(&head.l);
+	    mk_addmember(bu_vls_cstr(&raw), &head.l, xform, WMOP_UNION);
+	    mk_lcomb(fd_out, bu_vls_cstr(&sname), &head, 0,
+		     (char *)NULL, (char *)NULL, (unsigned char *)NULL, 0);
+	    bu_vls_free(&raw);
+	}
+    }
+
+    bu_vls_vlscat(out_name, &sname);
+    bu_vls_free(&sname);
+
+    skip_ws();
+    if (pos < buf_len && buf[pos] == ';')
+	pos++;
+
+    return 1;
+}
+
+
+/*
  * Skip an unrecognized node: consume identifier, params, and
  * optional { children } block.
  */
@@ -777,11 +1239,15 @@ parse_node(struct bu_vls *out_name, mat_t xform)
 	consume("cylinder");
 	return parse_cylinder(out_name, xform);
     }
+    if (looking_at("polyhedron")) {
+	consume("polyhedron");
+	return parse_polyhedron(out_name, xform);
+    }
 
     /* Unsupported nodes: warn and skip */
     if (looking_at("linear_extrude") || looking_at("rotate_extrude") ||
 	looking_at("hull") || looking_at("minkowski") ||
-	looking_at("polyhedron") || looking_at("polygon") ||
+	looking_at("polygon") ||
 	looking_at("square") || looking_at("circle") ||
 	looking_at("render") || looking_at("import")) {
 	size_t start = pos;

--- a/src/conv/csg/csg-g.c
+++ b/src/conv/csg/csg-g.c
@@ -940,6 +940,299 @@ try_arb5(double verts[][3], int nv,
 
 
 /*
+ * Try to match a polyhedron to an ARB6 (wedge / triangular prism).
+ * Must have 6 vertices, 5 faces: 2 triangles + 3 quads.
+ * The two triangle faces must share no vertices (they are the
+ * opposing ends of the prism).
+ *
+ * mk_arb6 layout: bottom quad (0,1,2,3), top edge (4,5)
+ * where pt8[4]=pt8[5] and pt8[6]=pt8[7].
+ *
+ * We find the two opposing triangles, pick one as bottom and
+ * pair its vertices with the top triangle's vertices via shared
+ * side faces.
+ */
+static int
+try_arb6(double verts[][3], int nv,
+	 int faces[][MAX_FACE_VERTS], int face_sizes[], int nf,
+	 fastf_t *pts)
+{
+    int i, j, k;
+    int tri_faces[2], tri_count = 0;
+    int quad_count = 0;
+    int bot_tri, top_tri;
+    int bot_verts[3], top_verts[3];
+    int paired[3]; /* top vertex paired with each bottom vertex */
+
+    if (nv != 6 || nf != 5)
+	return 0;
+
+    /* Must have exactly 2 triangles and 3 quads */
+    for (i = 0; i < 5; i++) {
+	if (face_sizes[i] == 3) {
+	    if (tri_count >= 2) return 0;
+	    tri_faces[tri_count++] = i;
+	} else if (face_sizes[i] == 4) {
+	    quad_count++;
+	} else {
+	    return 0;
+	}
+    }
+    if (tri_count != 2 || quad_count != 3)
+	return 0;
+
+    /* The two triangles must share no vertices */
+    for (j = 0; j < 3; j++)
+	for (k = 0; k < 3; k++)
+	    if (faces[tri_faces[0]][j] == faces[tri_faces[1]][k])
+		return 0;
+
+    bot_tri = tri_faces[0];
+    top_tri = tri_faces[1];
+
+    for (i = 0; i < 3; i++) {
+	bot_verts[i] = faces[bot_tri][i];
+	top_verts[i] = faces[top_tri][i];
+    }
+
+    /* Pair each bottom vertex with a top vertex via shared quad faces */
+    for (i = 0; i < 3; i++) {
+	int found = 0;
+	for (j = 0; j < 5 && !found; j++) {
+	    if (j == bot_tri || j == top_tri)
+		continue;
+	    if (face_sizes[j] != 4)
+		continue;
+	    /* Does this quad contain bot_verts[i]? */
+	    int has_bot = 0;
+	    for (k = 0; k < 4; k++) {
+		if (faces[j][k] == bot_verts[i]) {
+		    has_bot = 1;
+		    break;
+		}
+	    }
+	    if (!has_bot)
+		continue;
+	    /* Find which top vertex is on this quad */
+	    int m;
+	    for (m = 0; m < 3; m++) {
+		int n;
+		for (n = 0; n < 4; n++) {
+		    if (faces[j][n] == top_verts[m]) {
+			paired[i] = top_verts[m];
+			found = 1;
+			break;
+		    }
+		}
+		if (found) break;
+	    }
+	}
+	if (!found)
+	    return 0;
+    }
+
+    /*
+     * mk_arb6 expects 6 points:
+     * 0,1,2,3 = bottom quad (but we have a triangle, so one pair
+     * of adjacent bottom verts maps to two arb6 slots).
+     * 4,5 = top edge (two of the three top verts that form the
+     * collapsed top quad).
+     *
+     * Actually, arb6 is: pt8[0-3] = one quad face,
+     * pt8[4]=pt8[5] = one top point, pt8[6]=pt8[7] = other top point.
+     * So the "bottom" is a quad and "top" is an edge.
+     *
+     * For a triangular prism, we need to identify which pair of
+     * bottom triangle edges aligns with which top vertex to form
+     * the quad face.  The quad faces each connect one bottom edge
+     * to one top edge.
+     *
+     * Simpler: the bottom triangle has 3 verts (B0, B1, B2) and
+     * the top triangle has 3 (T0, T1, T2) with pairing
+     * B0-T(paired[0]), B1-T(paired[1]), B2-T(paired[2]).
+     *
+     * arb6 pts: 0=B0, 1=B1, 2=B2, 3=B2 (degenerate), 4=T(paired[0]), 5=T(paired[1])
+     * Wait, that's not right. Let me look at the arb8 face layout again.
+     *
+     * arb6 as arb8: pt[0-3] = bottom, pt[4]=pt[5], pt[6]=pt[7]
+     * Faces: 0123 (bottom quad), 4567 (top - degenerate edge),
+     * 0347, 1265, 0154, 2376
+     *
+     * For a tri prism: bottom=B0,B1,B2 top=T0,T1,T2
+     * Map: pt0=B0, pt1=B1, pt2=B2, pt3=B0 (degenerate)
+     *       pt4=T(p0), pt5=T(p0) (degenerate), pt6=T(p2), pt7=T(p2) (degenerate)
+     *
+     * Hmm, that doesn't work for a general prism. Let me just use
+     * the face connectivity to build the mapping properly.
+     */
+
+    /* For arb6: two of the three top vertices become the top edge,
+     * the third top vertex gets paired with two bottom vertices to
+     * form a triangular "end" that maps to a degenerate quad.
+     *
+     * Actually the simplest correct mapping:
+     * pts[0] = B0, pts[1] = B1, pts[2] = paired_top_of_B1,
+     * pts[3] = paired_top_of_B0, pts[4] = B2, pts[5] = paired_top_of_B2
+     */
+    VMOVE(&pts[0*3], verts[bot_verts[0]]);
+    VMOVE(&pts[1*3], verts[bot_verts[1]]);
+    VMOVE(&pts[2*3], verts[paired[1]]);
+    VMOVE(&pts[3*3], verts[paired[0]]);
+    VMOVE(&pts[4*3], verts[bot_verts[2]]);
+    VMOVE(&pts[5*3], verts[paired[2]]);
+
+    return 1;
+}
+
+
+/*
+ * Try to match a polyhedron to an ARB7.
+ * Must have 7 vertices, 6 faces: at least one triangle
+ * (the degenerate quad from the collapsed vertex).
+ *
+ * ARB7 is an ARB8 with pt[4]=pt[7] — one corner of the top
+ * face collapsed.  This gives 6 faces: the bottom quad, a
+ * triangle (where the collapse happened), and 4 quads.
+ *
+ * We find the single triangle face, identify which vertex is
+ * NOT on it (the opposite "bottom" face vertex), then order
+ * everything to match the arb8 layout.
+ */
+static int
+try_arb7(double verts[][3], int nv,
+	 int faces[][MAX_FACE_VERTS], int face_sizes[], int nf,
+	 fastf_t *pts)
+{
+    int i, j, k;
+    int tri_count = 0;
+    int quad_count = 0;
+
+    if (nv != 7 || nf != 6)
+	return 0;
+
+    /* Count face types: expect exactly 1 triangle and 5 quads,
+     * OR 2 triangles and 4 quads (if a quad degenerates) */
+    for (i = 0; i < 6; i++) {
+	if (face_sizes[i] == 3) {
+	    tri_count++;
+	} else if (face_sizes[i] == 4) {
+	    quad_count++;
+	} else {
+	    return 0;
+	}
+    }
+
+    /* Expect 2 triangles + 4 quads (collapsing one arb8 vertex
+     * degenerates two adjacent quad faces into triangles) */
+    if (tri_count != 2 || quad_count != 4)
+	return 0;
+
+    /*
+     * The two triangles share exactly one vertex — the collapsed
+     * corner.  One triangle has 3 top vertices (degenerate top quad),
+     * the other has 2 bottom + 1 top (degenerate side quad).
+     *
+     * Find the bottom quad face (the only quad that opposes one of
+     * the triangles — shares no vertices with it).
+     */
+    {
+	int tri_a = -1, tri_b = -1;
+	int bot_face = -1;
+	int bot_idx[4];
+	int on_bot[7];
+	int tc = 0;
+
+	for (i = 0; i < 6; i++) {
+	    if (face_sizes[i] == 3) {
+		if (tc == 0) tri_a = i;
+		else tri_b = i;
+		tc++;
+	    }
+	}
+
+	/* Try each quad to see if it opposes one of the triangles */
+	for (i = 0; i < 6; i++) {
+	    if (face_sizes[i] != 4)
+		continue;
+	    /* Check against tri_a */
+	    int shared = 0;
+	    for (j = 0; j < 4 && !shared; j++)
+		for (k = 0; k < 3; k++)
+		    if (faces[i][j] == faces[tri_a][k]) { shared = 1; break; }
+	    if (!shared) { bot_face = i; break; }
+	    /* Check against tri_b */
+	    shared = 0;
+	    for (j = 0; j < 4 && !shared; j++)
+		for (k = 0; k < 3; k++)
+		    if (faces[i][j] == faces[tri_b][k]) { shared = 1; break; }
+	    if (!shared) { bot_face = i; break; }
+	}
+	if (bot_face < 0)
+	    return 0;
+
+	for (i = 0; i < 4; i++)
+	    bot_idx[i] = faces[bot_face][i];
+
+	/* Identify top vs bottom vertices */
+	memset(on_bot, 0, sizeof(on_bot));
+	for (i = 0; i < 4; i++)
+	    on_bot[bot_idx[i]] = 1;
+
+	/* Pair each bottom vertex with a top vertex via side faces */
+	int top_for_bot[4];
+	for (i = 0; i < 4; i++)
+	    top_for_bot[i] = -1;
+
+	for (i = 0; i < 4; i++) {
+	    for (j = 0; j < 6; j++) {
+		if (j == bot_face)
+		    continue;
+		/* Does this face contain bot_idx[i]? */
+		int has_bot = 0, bot_pos = -1;
+		int fs = face_sizes[j];
+		for (k = 0; k < fs; k++) {
+		    if (faces[j][k] == bot_idx[i]) {
+			has_bot = 1;
+			bot_pos = k;
+			break;
+		    }
+		}
+		if (!has_bot)
+		    continue;
+		/* Find adjacent vertex that is a top vertex */
+		int prev = (bot_pos + fs - 1) % fs;
+		int next = (bot_pos + 1) % fs;
+		int candidates[2];
+		candidates[0] = faces[j][prev];
+		candidates[1] = faces[j][next];
+		int c;
+		for (c = 0; c < 2; c++) {
+		    if (!on_bot[candidates[c]]) {
+			top_for_bot[i] = candidates[c];
+			break;
+		    }
+		}
+		if (top_for_bot[i] >= 0)
+		    break;
+	    }
+	    if (top_for_bot[i] < 0)
+		return 0;
+	}
+
+	/* mk_arb7: 7 points, pt8[7]=pt8[4] internally */
+	VMOVE(&pts[0*3], verts[bot_idx[0]]);
+	VMOVE(&pts[1*3], verts[bot_idx[1]]);
+	VMOVE(&pts[2*3], verts[bot_idx[2]]);
+	VMOVE(&pts[3*3], verts[bot_idx[3]]);
+	VMOVE(&pts[4*3], verts[top_for_bot[0]]);
+	VMOVE(&pts[5*3], verts[top_for_bot[1]]);
+	VMOVE(&pts[6*3], verts[top_for_bot[2]]);
+    }
+    return 1;
+}
+
+
+/*
  * Create a BOT (Bag of Triangles) from a polyhedron.
  * Triangulates any non-triangular faces using a simple fan.
  */
@@ -1173,6 +1466,40 @@ parse_polyhedron(struct bu_vls *out_name, mat_t xform)
 	    struct wmember head;
 	    bu_vls_sprintf(&raw, "s.raw.%d", solid_count);
 	    mk_arb5(fd_out, bu_vls_cstr(&raw), arb_pts);
+	    BU_LIST_INIT(&head.l);
+	    mk_addmember(bu_vls_cstr(&raw), &head.l, xform, WMOP_UNION);
+	    mk_lcomb(fd_out, bu_vls_cstr(&sname), &head, 0,
+		     (char *)NULL, (char *)NULL, (unsigned char *)NULL, 0);
+	    bu_vls_free(&raw);
+	}
+    } else if (try_arb6(verts, nv, faces, face_sizes, nf, arb_pts)) {
+	if (debug)
+	    bu_log("  polyhedron: %s matched arb6 (%d verts, %d faces)\n",
+		   bu_vls_cstr(&sname), nv, nf);
+	if (bn_mat_is_identity(xform)) {
+	    mk_arb6(fd_out, bu_vls_cstr(&sname), arb_pts);
+	} else {
+	    struct bu_vls raw = BU_VLS_INIT_ZERO;
+	    struct wmember head;
+	    bu_vls_sprintf(&raw, "s.raw.%d", solid_count);
+	    mk_arb6(fd_out, bu_vls_cstr(&raw), arb_pts);
+	    BU_LIST_INIT(&head.l);
+	    mk_addmember(bu_vls_cstr(&raw), &head.l, xform, WMOP_UNION);
+	    mk_lcomb(fd_out, bu_vls_cstr(&sname), &head, 0,
+		     (char *)NULL, (char *)NULL, (unsigned char *)NULL, 0);
+	    bu_vls_free(&raw);
+	}
+    } else if (try_arb7(verts, nv, faces, face_sizes, nf, arb_pts)) {
+	if (debug)
+	    bu_log("  polyhedron: %s matched arb7 (%d verts, %d faces)\n",
+		   bu_vls_cstr(&sname), nv, nf);
+	if (bn_mat_is_identity(xform)) {
+	    mk_arb7(fd_out, bu_vls_cstr(&sname), arb_pts);
+	} else {
+	    struct bu_vls raw = BU_VLS_INIT_ZERO;
+	    struct wmember head;
+	    bu_vls_sprintf(&raw, "s.raw.%d", solid_count);
+	    mk_arb7(fd_out, bu_vls_cstr(&raw), arb_pts);
 	    BU_LIST_INIT(&head.l);
 	    mk_addmember(bu_vls_cstr(&raw), &head.l, xform, WMOP_UNION);
 	    mk_lcomb(fd_out, bu_vls_cstr(&sname), &head, 0,

--- a/src/conv/csg/csg-g.c
+++ b/src/conv/csg/csg-g.c
@@ -1545,6 +1545,213 @@ parse_linear_extrude(struct bu_vls *out_name, mat_t xform)
 	bu_vls_vlscat(out_name, &sname);
 	bu_vls_free(&sname);
 	return 1;
+
+    } else if (looking_at("polygon")) {
+	/*
+	 * polygon(points=[[x,y],...], paths=[[i,j,...]])
+	 * Build a sketch from the polygon vertices and line segments,
+	 * then extrude it along Z.
+	 */
+	double poly_pts[MAX_POLY_VERTS][2];
+	int poly_paths[MAX_POLY_FACES][MAX_FACE_VERTS];
+	int path_sizes[MAX_POLY_FACES];
+	int npv = 0, npa = 0;
+	size_t poly_save;
+
+	consume("polygon");
+	skip_ws();
+	if (!expect_char('('))
+	    goto fallback;
+
+	poly_save = pos;
+
+	/* Parse points = [[x,y], ...] */
+	while (pos < buf_len && buf[pos] != ')') {
+	    skip_ws();
+	    if (pos + 6 < buf_len && bu_strncmp(&buf[pos], "points", 6) == 0) {
+		size_t p = pos + 6;
+		while (p < buf_len && isspace((int)buf[p])) p++;
+		if (p < buf_len && buf[p] == '=') {
+		    p++;
+		    while (p < buf_len && isspace((int)buf[p])) p++;
+		    if (p < buf_len && buf[p] == '[') {
+			pos = p + 1;
+			while (npv < MAX_POLY_VERTS) {
+			    skip_ws();
+			    if (pos < buf_len && buf[pos] == ']') break;
+			    if (npv > 0) { skip_ws(); if (pos < buf_len && buf[pos] == ',') pos++; }
+			    skip_ws();
+			    if (!expect_char('[')) break;
+			    poly_pts[npv][0] = parse_double(); skip_ws(); expect_char(',');
+			    poly_pts[npv][1] = parse_double(); skip_ws();
+			    if (!expect_char(']')) break;
+			    npv++;
+			}
+			skip_ws();
+			if (pos < buf_len && buf[pos] == ']') pos++;
+		    }
+		}
+		break;
+	    }
+	    pos++;
+	}
+
+	/* Parse paths = [[i,j,...], ...] (optional) */
+	pos = poly_save;
+	while (pos < buf_len && buf[pos] != ')') {
+	    skip_ws();
+	    if (pos + 5 < buf_len && bu_strncmp(&buf[pos], "paths", 5) == 0) {
+		size_t p = pos + 5;
+		while (p < buf_len && isspace((int)buf[p])) p++;
+		if (p < buf_len && buf[p] == '=') {
+		    p++;
+		    while (p < buf_len && isspace((int)buf[p])) p++;
+		    if (p < buf_len && buf[p] == '[') {
+			pos = p + 1;
+			while (npa < MAX_POLY_FACES) {
+			    int pv = 0;
+			    skip_ws();
+			    if (pos < buf_len && buf[pos] == ']') break;
+			    if (npa > 0) { skip_ws(); if (pos < buf_len && buf[pos] == ',') pos++; }
+			    skip_ws();
+			    if (!expect_char('[')) break;
+			    while (pv < MAX_FACE_VERTS) {
+				double fval;
+				skip_ws();
+				if (pos < buf_len && buf[pos] == ']') break;
+				if (pv > 0) { skip_ws(); if (pos < buf_len && buf[pos] == ',') pos++; }
+				fval = parse_double();
+				poly_paths[npa][pv] = (int)fval;
+				pv++;
+			    }
+			    path_sizes[npa] = pv;
+			    skip_ws();
+			    if (pos < buf_len && buf[pos] == ']') pos++;
+			    npa++;
+			}
+			skip_ws();
+			if (pos < buf_len && buf[pos] == ']') pos++;
+		    }
+		}
+		break;
+	    }
+	    pos++;
+	}
+
+	/* Skip to end of polygon params */
+	while (pos < buf_len && buf[pos] != ')')
+	    pos++;
+	if (pos < buf_len) pos++;
+	skip_ws();
+	if (pos < buf_len && buf[pos] == ';') pos++;
+
+	skip_ws();
+	expect_char('}'); /* close linear_extrude block */
+
+	if (npv < 3) {
+	    bu_log("WARNING: polygon with < 3 vertices, skipping\n");
+	    bu_vls_free(&sname);
+	    return 0;
+	}
+
+	/* If no paths provided, default path is all vertices in order */
+	if (npa == 0) {
+	    int vi;
+	    npa = 1;
+	    path_sizes[0] = npv;
+	    for (vi = 0; vi < npv; vi++)
+		poly_paths[0][vi] = vi;
+	}
+
+	/* Build sketch + extrusion */
+	{
+	    struct rt_sketch_internal skt;
+	    struct bu_vls skt_name = BU_VLS_INIT_ZERO;
+	    struct line_seg *lsegs;
+	    int *reverses;
+	    void **segs;
+	    point2d_t *verts2d;
+	    int nseg = 0;
+	    int pi, si;
+	    point_t ext_V;
+	    vect_t ext_h, ext_u, ext_v;
+
+	    /* Count total segments across all paths */
+	    for (pi = 0; pi < npa; pi++)
+		nseg += path_sizes[pi];
+
+	    verts2d = (point2d_t *)bu_calloc(npv, sizeof(point2d_t), "sketch verts");
+	    lsegs = (struct line_seg *)bu_calloc(nseg, sizeof(struct line_seg), "sketch segs");
+	    reverses = (int *)bu_calloc(nseg, sizeof(int), "sketch reverse");
+	    segs = (void **)bu_calloc(nseg, sizeof(void *), "sketch seg ptrs");
+
+	    for (si = 0; si < npv; si++) {
+		verts2d[si][0] = poly_pts[si][0];
+		verts2d[si][1] = poly_pts[si][1];
+	    }
+
+	    si = 0;
+	    for (pi = 0; pi < npa; pi++) {
+		int vi;
+		for (vi = 0; vi < path_sizes[pi]; vi++) {
+		    lsegs[si].magic = CURVE_LSEG_MAGIC;
+		    lsegs[si].start = poly_paths[pi][vi];
+		    lsegs[si].end = poly_paths[pi][(vi + 1) % path_sizes[pi]];
+		    reverses[si] = 0;
+		    segs[si] = (void *)&lsegs[si];
+		    si++;
+		}
+	    }
+
+	    skt.magic = RT_SKETCH_INTERNAL_MAGIC;
+	    VSET(ext_V, 0.0, 0.0, centered ? -height/2.0 : 0.0);
+	    VSET(ext_u, 1.0, 0.0, 0.0);
+	    VSET(ext_v, 0.0, 1.0, 0.0);
+	    VMOVE(skt.V, ext_V);
+	    VMOVE(skt.u_vec, ext_u);
+	    VMOVE(skt.v_vec, ext_v);
+	    skt.vert_count = npv;
+	    skt.verts = verts2d;
+	    skt.curve.count = nseg;
+	    skt.curve.reverse = reverses;
+	    skt.curve.segment = segs;
+
+	    make_solid_name(&sname);
+	    bu_vls_sprintf(&skt_name, "%s.sketch", bu_vls_cstr(&sname));
+
+	    mk_sketch(fd_out, bu_vls_cstr(&skt_name), &skt);
+
+	    VSET(ext_h, 0.0, 0.0, height);
+	    mk_extrusion(fd_out, bu_vls_cstr(&sname),
+			 bu_vls_cstr(&skt_name), ext_V, ext_h,
+			 ext_u, ext_v, 0);
+
+	    if (!bn_mat_is_identity(xform)) {
+		struct bu_vls wrapper = BU_VLS_INIT_ZERO;
+		struct wmember head_w;
+		bu_vls_sprintf(&wrapper, "%s.x", bu_vls_cstr(&sname));
+		BU_LIST_INIT(&head_w.l);
+		mk_addmember(bu_vls_cstr(&sname), &head_w.l, xform, WMOP_UNION);
+		mk_lcomb(fd_out, bu_vls_cstr(&wrapper), &head_w, 0,
+			 (char *)NULL, (char *)NULL, (unsigned char *)NULL, 0);
+		bu_vls_vlscat(out_name, &wrapper);
+		bu_vls_free(&wrapper);
+	    } else {
+		bu_vls_vlscat(out_name, &sname);
+	    }
+
+	    if (debug)
+		bu_log("  linear_extrude(polygon): %s (%d verts, %d paths, h=%g)\n",
+		       bu_vls_cstr(&sname), npv, npa, height);
+
+	    bu_free(verts2d, "sketch verts");
+	    bu_free(lsegs, "sketch segs");
+	    bu_free(reverses, "sketch reverse");
+	    bu_free(segs, "sketch seg ptrs");
+	    bu_vls_free(&skt_name);
+	    bu_vls_free(&sname);
+	    return 1;
+	}
     }
 
 fallback:

--- a/src/conv/csg/g-scad.c
+++ b/src/conv/csg/g-scad.c
@@ -683,6 +683,53 @@ emit_object(const char *name)
 		    break;
 		}
 
+	    case ID_HALF:
+		{
+		    /*
+		     * Halfspace: infinite solid on one side of a plane.
+		     * OpenSCAD has no infinite solids, so we approximate
+		     * with a very large cube positioned on the correct
+		     * side of the plane.
+		     */
+		    struct rt_half_internal *half = (struct rt_half_internal *)intern.idb_ptr;
+		    double d = half->eqn[W]; /* distance from origin along normal */
+		    vect_t normal;
+		    mat_t m;
+		    vect_t a_vec, b_vec;
+		    double big = 1.0e10;
+
+		    VMOVE(normal, half->eqn);
+
+		    /* Build coordinate frame: normal = Z, a/b = X/Y */
+		    bn_vec_ortho(a_vec, normal);
+		    VCROSS(b_vec, normal, a_vec);
+		    VUNITIZE(a_vec);
+		    VUNITIZE(b_vec);
+
+		    /*
+		     * Place a huge cube so its +Z face is at the plane.
+		     * The cube extends from -big to 0 in the local Z
+		     * (normal) direction, and -big to +big in X/Y.
+		     * The origin of local space is at d * normal.
+		     */
+		    MAT_ZERO(m);
+		    m[0]  = a_vec[0]; m[4]  = b_vec[0]; m[8]  = normal[0]; m[12] = normal[0] * d;
+		    m[1]  = a_vec[1]; m[5]  = b_vec[1]; m[9]  = normal[1]; m[13] = normal[1] * d;
+		    m[2]  = a_vec[2]; m[6]  = b_vec[2]; m[10] = normal[2]; m[14] = normal[2] * d;
+		    m[15] = 1.0;
+
+		    emit_matrix_open(m);
+		    print_indent();
+		    fprintf(fd_out, "translate([%g, %g, %g])\n", -big, -big, -2.0 * big);
+		    indent_level++;
+		    print_indent();
+		    fprintf(fd_out, "cube([%g, %g, %g]);\n", 2.0 * big, 2.0 * big, 2.0 * big);
+		    indent_level--;
+		    emit_matrix_close(m);
+		    solid_count++;
+		    break;
+		}
+
 	    case ID_EXTRUDE:
 		{
 		    struct rt_extrude_internal *extr = (struct rt_extrude_internal *)intern.idb_ptr;

--- a/src/conv/csg/g-scad.c
+++ b/src/conv/csg/g-scad.c
@@ -660,6 +660,146 @@ emit_object(const char *name)
 		    break;
 		}
 
+	    case ID_EXTRUDE:
+		{
+		    struct rt_extrude_internal *extr = (struct rt_extrude_internal *)intern.idb_ptr;
+		    struct rt_sketch_internal *skt = NULL;
+		    struct directory *skt_dp;
+		    struct rt_db_internal skt_intern;
+		    mat_t m;
+		    vect_t h_unit;
+		    double h_len;
+
+		    /* Load the referenced sketch */
+		    skt_dp = db_lookup(dbip, extr->sketch_name, LOOKUP_QUIET);
+		    if (skt_dp == RT_DIR_NULL) {
+			bu_log("WARNING: sketch '%s' not found for extrude %s\n",
+			       extr->sketch_name, name);
+			emit_tessellated(name, &intern);
+			break;
+		    }
+		    if (rt_db_get_internal(&skt_intern, skt_dp, dbip, NULL, &rt_uniresource) < 0) {
+			bu_log("WARNING: failed to read sketch '%s'\n", extr->sketch_name);
+			emit_tessellated(name, &intern);
+			break;
+		    }
+		    skt = (struct rt_sketch_internal *)skt_intern.idb_ptr;
+
+		    h_len = MAGNITUDE(extr->h);
+
+		    /* Build transform from sketch plane to world */
+		    MAT_ZERO(m);
+		    m[0]  = extr->u_vec[0]; m[4]  = extr->v_vec[0]; m[12] = extr->V[0];
+		    m[1]  = extr->u_vec[1]; m[5]  = extr->v_vec[1]; m[13] = extr->V[1];
+		    m[2]  = extr->u_vec[2]; m[6]  = extr->v_vec[2]; m[14] = extr->V[2];
+		    /* H direction as Z of the local frame */
+		    if (h_len > tol.dist) {
+			VSCALE(h_unit, extr->h, 1.0 / h_len);
+			m[8]  = h_unit[0];
+			m[9]  = h_unit[1];
+			m[10] = h_unit[2];
+		    }
+		    m[15] = 1.0;
+
+		    emit_matrix_open(m);
+
+		    print_indent();
+		    fprintf(fd_out, "linear_extrude(height = %g) {\n", h_len);
+		    indent_level++;
+
+		    /* Emit polygon from sketch vertices and line segments */
+		    {
+			size_t vi;
+			size_t si;
+			int has_lines = 0;
+
+			print_indent();
+			fprintf(fd_out, "polygon(\n");
+			indent_level++;
+
+			/* Points */
+			print_indent();
+			fprintf(fd_out, "points = [\n");
+			indent_level++;
+			for (vi = 0; vi < skt->vert_count; vi++) {
+			    print_indent();
+			    fprintf(fd_out, "[%g, %g]%s\n",
+				    skt->verts[vi][0], skt->verts[vi][1],
+				    (vi < skt->vert_count - 1) ? "," : "");
+			}
+			indent_level--;
+			print_indent();
+			fprintf(fd_out, "],\n");
+
+			/* Paths — collect line segment chains */
+			/* For simplicity, emit one path per closed loop.
+			 * Walk line segments to find connected chains. */
+			print_indent();
+			fprintf(fd_out, "paths = [\n");
+			indent_level++;
+
+			/* Simple approach: emit vertex indices from line
+			 * segments in order. */
+			for (si = 0; si < skt->curve.count; si++) {
+			    uint32_t *magic_p = (uint32_t *)skt->curve.segment[si];
+			    if (*magic_p == CURVE_LSEG_MAGIC) {
+				has_lines = 1;
+				break;
+			    }
+			}
+
+			if (has_lines) {
+			    /* Collect all start vertices from line segments as a single path */
+			    print_indent();
+			    fprintf(fd_out, "[");
+			    {
+				int first = 1;
+				for (si = 0; si < skt->curve.count; si++) {
+				    uint32_t *magic_p = (uint32_t *)skt->curve.segment[si];
+				    if (*magic_p == CURVE_LSEG_MAGIC) {
+					struct line_seg *lseg = (struct line_seg *)skt->curve.segment[si];
+					if (!first) fprintf(fd_out, ", ");
+					fprintf(fd_out, "%d", lseg->start);
+					first = 0;
+				    }
+				}
+			    }
+			    fprintf(fd_out, "]\n");
+			} else {
+			    /* No line segments — emit default path */
+			    print_indent();
+			    fprintf(fd_out, "[");
+			    for (vi = 0; vi < skt->vert_count; vi++) {
+				fprintf(fd_out, "%zu%s", vi,
+					(vi < skt->vert_count - 1) ? ", " : "");
+			    }
+			    fprintf(fd_out, "]\n");
+			}
+
+			indent_level--;
+			print_indent();
+			fprintf(fd_out, "]\n");
+
+			indent_level--;
+			print_indent();
+			fprintf(fd_out, ");\n");
+		    }
+
+		    indent_level--;
+		    print_indent();
+		    fprintf(fd_out, "}\n");
+
+		    emit_matrix_close(m);
+		    rt_db_free_internal(&skt_intern);
+		    solid_count++;
+		    break;
+		}
+
+	    case ID_SKETCH:
+		/* Sketches are referenced by extrusions, not standalone geometry.
+		 * If encountered alone, skip silently. */
+		break;
+
 	    default:
 		/* Try tessellation for unsupported types */
 		emit_tessellated(name, &intern);

--- a/src/conv/csg/g-scad.c
+++ b/src/conv/csg/g-scad.c
@@ -1,0 +1,786 @@
+/*                       G - S C A D . C
+ * BRL-CAD
+ *
+ * Copyright (c) 2025 United States Government as represented by
+ * the U.S. Army Research Laboratory.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this file; see the file named COPYING for more
+ * information.
+ *
+ */
+/** @file csg/g-scad.c
+ *
+ * Convert BRL-CAD .g format to OpenSCAD .scad format.
+ *
+ * Walks the CSG tree preserving boolean structure, transforms, and
+ * primitive geometry.  Primitives with direct OpenSCAD equivalents
+ * (sphere, cylinder, cube-like ARBs) are emitted analytically.
+ * Others are tessellated to polyhedron().
+ *
+ */
+
+#include "common.h"
+
+#include <stdlib.h>
+#include <math.h>
+#include <string.h>
+#include "bio.h"
+
+#include "bu/app.h"
+#include "bu/getopt.h"
+#include "bu/log.h"
+#include "bu/malloc.h"
+#include "bu/str.h"
+#include "bu/vls.h"
+#include "vmath.h"
+#include "bn/tol.h"
+#include "nmg.h"
+#include "rt/geom.h"
+#include "rt/nmg_conv.h"
+#include "raytrace.h"
+#include "wdb.h"
+
+
+static struct db_i *dbip;		/* database instance */
+static FILE *fd_out;			/* output file */
+static int debug = 0;			/* debug flag */
+static int indent_level = 0;		/* current output indentation */
+static struct bn_tol tol;		/* tolerance */
+static struct bg_tess_tol ttol;		/* tessellation tolerance */
+static int solid_count = 0;		/* statistics */
+static int comb_count = 0;
+
+
+/*
+ * Print indentation for the current nesting level.
+ */
+static void
+print_indent(void)
+{
+    int i;
+    for (i = 0; i < indent_level; i++)
+	fprintf(fd_out, "\t");
+}
+
+
+/*
+ * Emit a 4x4 transformation matrix as multmatrix().
+ * BRL-CAD stores column-major; OpenSCAD expects row-major.
+ */
+static void
+emit_matrix_open(matp_t m)
+{
+    if (!m || bn_mat_is_identity(m))
+	return;
+
+    print_indent();
+    fprintf(fd_out, "multmatrix([\n");
+    indent_level++;
+    print_indent();
+    fprintf(fd_out, "[%g, %g, %g, %g],\n",
+	    m[0], m[4], m[8], m[12]);
+    print_indent();
+    fprintf(fd_out, "[%g, %g, %g, %g],\n",
+	    m[1], m[5], m[9], m[13]);
+    print_indent();
+    fprintf(fd_out, "[%g, %g, %g, %g],\n",
+	    m[2], m[6], m[10], m[14]);
+    print_indent();
+    fprintf(fd_out, "[%g, %g, %g, %g]\n",
+	    m[3], m[7], m[11], m[15]);
+    indent_level--;
+    print_indent();
+    fprintf(fd_out, "]) {\n");
+    indent_level++;
+}
+
+
+static void
+emit_matrix_close(matp_t m)
+{
+    if (!m || bn_mat_is_identity(m))
+	return;
+
+    indent_level--;
+    print_indent();
+    fprintf(fd_out, "}\n");
+}
+
+
+/*
+ * Check if an ellipsoid is actually a sphere (all axes equal length).
+ */
+static int
+ell_is_sphere(struct rt_ell_internal *ell, double *radius)
+{
+    double la = MAGNITUDE(ell->a);
+    double lb = MAGNITUDE(ell->b);
+    double lc = MAGNITUDE(ell->c);
+
+    if (NEAR_EQUAL(la, lb, tol.dist) && NEAR_EQUAL(lb, lc, tol.dist)) {
+	*radius = la;
+	return 1;
+    }
+    return 0;
+}
+
+
+/*
+ * Check if a TGC is a right circular cylinder or cone (circular cross
+ * sections, height perpendicular to base, A/B and C/D equal length).
+ */
+static int
+tgc_is_cylinder(struct rt_tgc_internal *tgc,
+		double *r1, double *r2, double *h)
+{
+    double la = MAGNITUDE(tgc->a);
+    double lb = MAGNITUDE(tgc->b);
+    double lc = MAGNITUDE(tgc->c);
+    double ld = MAGNITUDE(tgc->d);
+    vect_t h_unit, a_unit, b_unit;
+
+    /* A and B must be equal length (circular base) */
+    if (!NEAR_EQUAL(la, lb, tol.dist))
+	return 0;
+    /* C and D must be equal length (circular top) */
+    if (!NEAR_EQUAL(lc, ld, tol.dist))
+	return 0;
+
+    /* A and B must be perpendicular */
+    if (!NEAR_ZERO(VDOT(tgc->a, tgc->b), tol.dist))
+	return 0;
+
+    /* H must be perpendicular to both A and B */
+    *h = MAGNITUDE(tgc->h);
+    if (*h < tol.dist)
+	return 0;
+
+    VSCALE(h_unit, tgc->h, 1.0 / *h);
+    VSCALE(a_unit, tgc->a, 1.0 / la);
+    VSCALE(b_unit, tgc->b, 1.0 / lb);
+
+    if (!NEAR_ZERO(VDOT(h_unit, a_unit), tol.perp))
+	return 0;
+    if (!NEAR_ZERO(VDOT(h_unit, b_unit), tol.perp))
+	return 0;
+
+    *r1 = la;
+    *r2 = lc;
+    return 1;
+}
+
+
+/*
+ * Emit a sphere primitive.
+ */
+static void
+emit_sphere(struct rt_ell_internal *ell)
+{
+    double r;
+
+    if (ell_is_sphere(ell, &r)) {
+	/* Pure sphere: emit translate + sphere */
+	print_indent();
+	fprintf(fd_out, "translate([%g, %g, %g])\n",
+		V3ARGS(ell->v));
+	indent_level++;
+	print_indent();
+	fprintf(fd_out, "sphere(r = %g);\n", r);
+	indent_level--;
+    } else {
+	/* General ellipsoid: emit translate + multmatrix + sphere(1) */
+	double la = MAGNITUDE(ell->a);
+	double lb = MAGNITUDE(ell->b);
+	double lc = MAGNITUDE(ell->c);
+	mat_t m;
+
+	MAT_ZERO(m);
+	/* Build matrix from ellipsoid axes */
+	m[0]  = ell->a[0]; m[4]  = ell->b[0]; m[8]  = ell->c[0]; m[12] = ell->v[0];
+	m[1]  = ell->a[1]; m[5]  = ell->b[1]; m[9]  = ell->c[1]; m[13] = ell->v[1];
+	m[2]  = ell->a[2]; m[6]  = ell->b[2]; m[10] = ell->c[2]; m[14] = ell->v[2];
+	m[15] = 1.0;
+
+	emit_matrix_open(m);
+	print_indent();
+	fprintf(fd_out, "sphere(r = 1);\n");
+	emit_matrix_close(m);
+
+	if (debug)
+	    bu_log("  ellipsoid axes: %g %g %g\n", la, lb, lc);
+    }
+    solid_count++;
+}
+
+
+/*
+ * Emit a TGC/cylinder primitive.
+ */
+static void
+emit_tgc(struct rt_tgc_internal *tgc)
+{
+    double r1, r2, h;
+
+    if (tgc_is_cylinder(tgc, &r1, &r2, &h)) {
+	/* Right circular cylinder/cone: translate + cylinder */
+	mat_t m;
+	vect_t h_unit;
+
+	VSCALE(h_unit, tgc->h, 1.0 / h);
+
+	/* If H is along Z axis, just translate */
+	if (NEAR_ZERO(h_unit[X], tol.perp) &&
+	    NEAR_ZERO(h_unit[Y], tol.perp) &&
+	    h_unit[Z] > 0) {
+	    print_indent();
+	    fprintf(fd_out, "translate([%g, %g, %g])\n",
+		    V3ARGS(tgc->v));
+	    indent_level++;
+	    print_indent();
+	    fprintf(fd_out, "cylinder(h = %g, r1 = %g, r2 = %g);\n",
+		    h, r1, r2);
+	    indent_level--;
+	} else {
+	    /* Need full transform */
+	    vect_t a_unit, b_unit;
+	    VSCALE(a_unit, tgc->a, 1.0 / r1);
+	    VSCALE(b_unit, tgc->b, 1.0 / r1);
+
+	    MAT_ZERO(m);
+	    m[0]  = a_unit[0]; m[4]  = b_unit[0]; m[8]  = h_unit[0]; m[12] = tgc->v[0];
+	    m[1]  = a_unit[1]; m[5]  = b_unit[1]; m[9]  = h_unit[1]; m[13] = tgc->v[1];
+	    m[2]  = a_unit[2]; m[6]  = b_unit[2]; m[10] = h_unit[2]; m[14] = tgc->v[2];
+	    m[15] = 1.0;
+
+	    emit_matrix_open(m);
+	    print_indent();
+	    fprintf(fd_out, "cylinder(h = %g, r1 = %g, r2 = %g);\n",
+		    h, r1, r2);
+	    emit_matrix_close(m);
+	}
+    } else {
+	/* General TGC: emit as transformed geometry using full axis matrix */
+	mat_t m;
+
+	MAT_ZERO(m);
+	m[0]  = tgc->a[0]; m[4]  = tgc->b[0]; m[8]  = tgc->h[0]; m[12] = tgc->v[0];
+	m[1]  = tgc->a[1]; m[5]  = tgc->b[1]; m[9]  = tgc->h[1]; m[13] = tgc->v[1];
+	m[2]  = tgc->a[2]; m[6]  = tgc->b[2]; m[10] = tgc->h[2]; m[14] = tgc->v[2];
+	m[15] = 1.0;
+
+	emit_matrix_open(m);
+	print_indent();
+	/* Unit cylinder scaled by matrix gives general TGC */
+	fprintf(fd_out, "cylinder(h = 1, r1 = 1, r2 = %g);\n",
+		MAGNITUDE(tgc->c) / MAGNITUDE(tgc->a));
+	emit_matrix_close(m);
+    }
+    solid_count++;
+}
+
+
+/*
+ * Emit an ARB as polyhedron().
+ */
+static void
+emit_arb(struct rt_arb_internal *arb)
+{
+    int i;
+    int unique[8];
+    int nunique = 0;
+    int map[8]; /* maps original index to unique index */
+
+    /* Find unique vertices (ARBs with < 8 verts have duplicates) */
+    for (i = 0; i < 8; i++) {
+	int j, found = 0;
+	for (j = 0; j < nunique; j++) {
+	    if (VNEAR_EQUAL(arb->pt[i], arb->pt[unique[j]], tol.dist)) {
+		map[i] = j;
+		found = 1;
+		break;
+	    }
+	}
+	if (!found) {
+	    map[i] = nunique;
+	    unique[nunique] = i;
+	    nunique++;
+	}
+    }
+
+    print_indent();
+    fprintf(fd_out, "polyhedron(\n");
+    indent_level++;
+
+    /* Points */
+    print_indent();
+    fprintf(fd_out, "points = [\n");
+    indent_level++;
+    for (i = 0; i < nunique; i++) {
+	print_indent();
+	fprintf(fd_out, "[%g, %g, %g]%s\n",
+		V3ARGS(arb->pt[unique[i]]),
+		(i < nunique - 1) ? "," : "");
+    }
+    indent_level--;
+    print_indent();
+    fprintf(fd_out, "],\n");
+
+    /* Faces — use the standard ARB8 face definitions, mapping to unique verts */
+    /* ARB8 faces: 0123, 7654, 0347, 1562, 0451, 3267 */
+    {
+	static const int arb8_faces[6][4] = {
+	    {0, 1, 2, 3}, {7, 6, 5, 4},
+	    {0, 3, 7, 4}, {1, 5, 6, 2},
+	    {0, 4, 5, 1}, {3, 2, 6, 7}
+	};
+
+	print_indent();
+	fprintf(fd_out, "faces = [\n");
+	indent_level++;
+
+	int nfaces = 0;
+	for (i = 0; i < 6; i++) {
+	    int fv[4], nfv = 0, j;
+
+	    /* Map and deduplicate face vertices */
+	    for (j = 0; j < 4; j++) {
+		int mv = map[arb8_faces[i][j]];
+		int dup = 0, k;
+		for (k = 0; k < nfv; k++) {
+		    if (fv[k] == mv) { dup = 1; break; }
+		}
+		if (!dup)
+		    fv[nfv++] = mv;
+	    }
+
+	    /* Skip degenerate faces (< 3 unique verts) */
+	    if (nfv < 3)
+		continue;
+
+	    if (nfaces > 0) {
+		fprintf(fd_out, ",\n");
+	    }
+	    print_indent();
+	    fprintf(fd_out, "[");
+	    for (j = 0; j < nfv; j++) {
+		fprintf(fd_out, "%d%s", fv[j], (j < nfv-1) ? ", " : "");
+	    }
+	    fprintf(fd_out, "]");
+	    nfaces++;
+	}
+	fprintf(fd_out, "\n");
+
+	indent_level--;
+	print_indent();
+	fprintf(fd_out, "]\n");
+    }
+
+    indent_level--;
+    print_indent();
+    fprintf(fd_out, ");\n");
+    solid_count++;
+}
+
+
+/*
+ * Emit a BOT (Bag of Triangles) as polyhedron().
+ */
+static void
+emit_bot(struct rt_bot_internal *bot)
+{
+    size_t i;
+
+    print_indent();
+    fprintf(fd_out, "polyhedron(\n");
+    indent_level++;
+
+    print_indent();
+    fprintf(fd_out, "points = [\n");
+    indent_level++;
+    for (i = 0; i < bot->num_vertices; i++) {
+	print_indent();
+	fprintf(fd_out, "[%g, %g, %g]%s\n",
+		bot->vertices[i*3+0],
+		bot->vertices[i*3+1],
+		bot->vertices[i*3+2],
+		(i < bot->num_vertices - 1) ? "," : "");
+    }
+    indent_level--;
+    print_indent();
+    fprintf(fd_out, "],\n");
+
+    print_indent();
+    fprintf(fd_out, "faces = [\n");
+    indent_level++;
+    for (i = 0; i < bot->num_faces; i++) {
+	print_indent();
+	fprintf(fd_out, "[%d, %d, %d]%s\n",
+		bot->faces[i*3+0],
+		bot->faces[i*3+1],
+		bot->faces[i*3+2],
+		(i < bot->num_faces - 1) ? "," : "");
+    }
+    indent_level--;
+    print_indent();
+    fprintf(fd_out, "]\n");
+
+    indent_level--;
+    print_indent();
+    fprintf(fd_out, ");\n");
+    solid_count++;
+}
+
+
+/*
+ * Emit an unsupported primitive by tessellating it to polyhedron().
+ * Uses the primitive's ft_tessellate to get NMG, then nmg_bot() to
+ * convert to triangles.
+ */
+static void
+emit_tessellated(const char *name, struct rt_db_internal *ip)
+{
+    struct model *m;
+    struct nmgregion *r;
+    struct shell *s;
+    struct rt_bot_internal *bot;
+    const struct rt_functab *ftp;
+
+    ftp = ip->idb_meth;
+    if (!ftp || !ftp->ft_tessellate) {
+	bu_log("WARNING: no tessellation method for %s, skipping\n", name);
+	return;
+    }
+
+    m = nmg_mm();
+    if (ftp->ft_tessellate(&r, m, ip, &ttol, &tol) < 0) {
+	bu_log("WARNING: tessellation failed for %s, skipping\n", name);
+	nmg_km(m);
+	return;
+    }
+
+    /* Convert the first shell to BOT */
+    s = BU_LIST_FIRST(shell, &r->s_hd);
+    {
+	struct bu_list vlfree;
+	BU_LIST_INIT(&vlfree);
+	bot = nmg_bot(s, &vlfree, &tol);
+    }
+    if (!bot || bot->num_faces == 0) {
+	bu_log("WARNING: empty tessellation for %s, skipping\n", name);
+	nmg_km(m);
+	return;
+    }
+
+    if (debug)
+	bu_log("  tessellated %s: %zu verts, %zu faces\n",
+	       name, bot->num_vertices, bot->num_faces);
+
+    emit_bot(bot);
+    nmg_km(m);
+}
+
+
+/* Forward declaration */
+static void emit_object(const char *name);
+
+
+/*
+ * Emit a boolean tree node as OpenSCAD CSG operations.
+ */
+static void
+emit_tree(union tree *tree)
+{
+    if (!tree)
+	return;
+
+    switch (tree->tr_op) {
+	case OP_DB_LEAF:
+	    emit_matrix_open(tree->tr_l.tl_mat);
+	    emit_object(tree->tr_l.tl_name);
+	    emit_matrix_close(tree->tr_l.tl_mat);
+	    break;
+
+	case OP_UNION:
+	    print_indent();
+	    fprintf(fd_out, "union() {\n");
+	    indent_level++;
+	    emit_tree(tree->tr_b.tb_left);
+	    emit_tree(tree->tr_b.tb_right);
+	    indent_level--;
+	    print_indent();
+	    fprintf(fd_out, "}\n");
+	    break;
+
+	case OP_SUBTRACT:
+	    print_indent();
+	    fprintf(fd_out, "difference() {\n");
+	    indent_level++;
+	    emit_tree(tree->tr_b.tb_left);
+	    emit_tree(tree->tr_b.tb_right);
+	    indent_level--;
+	    print_indent();
+	    fprintf(fd_out, "}\n");
+	    break;
+
+	case OP_INTERSECT:
+	    print_indent();
+	    fprintf(fd_out, "intersection() {\n");
+	    indent_level++;
+	    emit_tree(tree->tr_b.tb_left);
+	    emit_tree(tree->tr_b.tb_right);
+	    indent_level--;
+	    print_indent();
+	    fprintf(fd_out, "}\n");
+	    break;
+
+	default:
+	    bu_log("WARNING: unhandled boolean op %d\n", tree->tr_op);
+	    break;
+    }
+}
+
+
+/*
+ * Emit a single database object (primitive or combination).
+ */
+static void
+emit_object(const char *name)
+{
+    struct directory *dp;
+    struct rt_db_internal intern;
+
+    dp = db_lookup(dbip, name, LOOKUP_QUIET);
+    if (dp == RT_DIR_NULL) {
+	bu_log("WARNING: object '%s' not found\n", name);
+	return;
+    }
+
+    if (rt_db_get_internal(&intern, dp, dbip, NULL, &rt_uniresource) < 0) {
+	bu_log("WARNING: failed to read '%s'\n", name);
+	return;
+    }
+
+    if (dp->d_flags & RT_DIR_COMB) {
+	/* Combination: emit boolean tree */
+	struct rt_comb_internal *comb = (struct rt_comb_internal *)intern.idb_ptr;
+	RT_CK_COMB(comb);
+
+	if (debug)
+	    bu_log("  combination: %s%s\n", name,
+		   comb->region_flag ? " (region)" : "");
+
+	/* Emit color if present */
+	if (comb->rgb_valid) {
+	    print_indent();
+	    fprintf(fd_out, "color([%g, %g, %g]) {\n",
+		    comb->rgb[0] / 255.0,
+		    comb->rgb[1] / 255.0,
+		    comb->rgb[2] / 255.0);
+	    indent_level++;
+	}
+
+	/* Add a comment with the combination name */
+	print_indent();
+	fprintf(fd_out, "/* %s */\n", name);
+
+	emit_tree(comb->tree);
+	comb_count++;
+
+	if (comb->rgb_valid) {
+	    indent_level--;
+	    print_indent();
+	    fprintf(fd_out, "}\n");
+	}
+    } else {
+	/* Primitive solid */
+	if (debug)
+	    bu_log("  solid: %s (type %d)\n", name, intern.idb_type);
+
+	print_indent();
+	fprintf(fd_out, "/* %s */\n", name);
+
+	switch (intern.idb_type) {
+	    case ID_ELL:
+	    case ID_SPH:
+		emit_sphere((struct rt_ell_internal *)intern.idb_ptr);
+		break;
+
+	    case ID_TGC:
+	    case ID_REC:
+		emit_tgc((struct rt_tgc_internal *)intern.idb_ptr);
+		break;
+
+	    case ID_ARB8:
+		emit_arb((struct rt_arb_internal *)intern.idb_ptr);
+		break;
+
+	    case ID_BOT:
+		emit_bot((struct rt_bot_internal *)intern.idb_ptr);
+		break;
+
+	    case ID_TOR:
+		{
+		    struct rt_tor_internal *tor = (struct rt_tor_internal *)intern.idb_ptr;
+		    mat_t m;
+		    vect_t h_unit, a_unit, b_unit;
+
+		    VMOVE(h_unit, tor->h);
+		    VUNITIZE(h_unit);
+		    bn_vec_ortho(a_unit, h_unit);
+		    VCROSS(b_unit, h_unit, a_unit);
+
+		    MAT_ZERO(m);
+		    m[0]  = a_unit[0]; m[4]  = b_unit[0]; m[8]  = h_unit[0]; m[12] = tor->v[0];
+		    m[1]  = a_unit[1]; m[5]  = b_unit[1]; m[9]  = h_unit[1]; m[13] = tor->v[1];
+		    m[2]  = a_unit[2]; m[6]  = b_unit[2]; m[10] = h_unit[2]; m[14] = tor->v[2];
+		    m[15] = 1.0;
+
+		    emit_matrix_open(m);
+		    print_indent();
+		    fprintf(fd_out, "rotate_extrude()\n");
+		    indent_level++;
+		    print_indent();
+		    fprintf(fd_out, "translate([%g, 0, 0])\n", tor->r_a);
+		    indent_level++;
+		    print_indent();
+		    fprintf(fd_out, "circle(r = %g);\n", tor->r_h);
+		    indent_level -= 2;
+		    emit_matrix_close(m);
+		    solid_count++;
+		    break;
+		}
+
+	    default:
+		/* Try tessellation for unsupported types */
+		emit_tessellated(name, &intern);
+		break;
+	}
+    }
+
+    rt_db_free_internal(&intern);
+}
+
+
+static void
+usage(const char *argv0)
+{
+    bu_log("Usage: %s [-d] [-o output.scad] input.g object [object ...]\n", argv0);
+    bu_log("	where input.g is a BRL-CAD database\n");
+    bu_log("	and object(s) are the top-level objects to export.\n");
+    bu_log("	The -d option prints additional debugging information.\n");
+    bu_log("	The -o option specifies the output file (default: stdout).\n");
+}
+
+
+int
+main(int argc, char *argv[])
+{
+    int c, i;
+    const char *output_file = NULL;
+
+    bu_setprogname(argv[0]);
+
+    tol.magic = BN_TOL_MAGIC;
+    tol.dist = 0.0005;
+    tol.dist_sq = tol.dist * tol.dist;
+    tol.perp = 1e-6;
+    tol.para = 1 - tol.perp;
+
+    ttol.magic = BG_TESS_TOL_MAGIC;
+    ttol.abs = 0.0;
+    ttol.rel = 0.01;
+    ttol.norm = 0.0;
+
+    if (argc < 3) {
+	usage(argv[0]);
+	bu_exit(1, NULL);
+    }
+
+    while ((c = bu_getopt(argc, argv, "do:")) != -1) {
+	switch (c) {
+	    case 'd':
+		debug = 1;
+		break;
+	    case 'o':
+		output_file = bu_optarg;
+		break;
+	    default:
+		usage(argv[0]);
+		bu_exit(1, NULL);
+		break;
+	}
+    }
+
+    if (bu_optind >= argc) {
+	usage(argv[0]);
+	bu_exit(1, "g-scad: need input file and object names\n");
+    }
+
+    /* Open BRL-CAD database */
+    dbip = db_open(argv[bu_optind], DB_OPEN_READONLY);
+    if (dbip == DBI_NULL) {
+	bu_log("Cannot open BRL-CAD file (%s)\n", argv[bu_optind]);
+	bu_exit(1, NULL);
+    }
+    if (db_dirbuild(dbip)) {
+	bu_log("db_dirbuild failed on %s\n", argv[bu_optind]);
+	bu_exit(1, NULL);
+    }
+    bu_optind++;
+
+    if (bu_optind >= argc) {
+	usage(argv[0]);
+	bu_exit(1, "g-scad: need object name(s)\n");
+    }
+
+    /* Open output */
+    if (output_file) {
+	fd_out = fopen(output_file, "w");
+	if (!fd_out) {
+	    bu_log("Cannot open output file (%s)\n", output_file);
+	    perror("g-scad");
+	    bu_exit(1, NULL);
+	}
+    } else {
+	fd_out = stdout;
+    }
+
+    fprintf(fd_out, "// Converted from BRL-CAD by g-scad\n");
+    fprintf(fd_out, "// Source: %s\n\n", argv[bu_optind - 1]);
+
+    /* Process each named object */
+    for (i = bu_optind; i < argc; i++) {
+	bu_log("Exporting: %s\n", argv[i]);
+	emit_object(argv[i]);
+    }
+
+    bu_log("Export complete: %d solids, %d combinations\n",
+	   solid_count, comb_count);
+
+    if (output_file)
+	fclose(fd_out);
+
+    db_close(dbip);
+    return 0;
+}
+
+
+/*
+ * Local Variables:
+ * mode: C
+ * tab-width: 8
+ * indent-tabs-mode: t
+ * c-file-style: "stroustrup"
+ * End:
+ * ex: shiftwidth=4 tabstop=8
+ */

--- a/src/conv/csg/g-scad.c
+++ b/src/conv/csg/g-scad.c
@@ -446,25 +446,46 @@ emit_bot(struct rt_bot_internal *bot)
  * Uses the primitive's ft_tessellate to get NMG, then nmg_bot() to
  * convert to triangles.
  */
+/*
+ * Tessellate a primitive by re-reading it from the database (to get
+ * a fresh copy that ft_tessellate can consume), converting to NMG,
+ * then to BOT.  We re-read because ft_tessellate can modify the
+ * internal structure, which would corrupt the caller's copy.
+ */
 static void
-emit_tessellated(const char *name, struct rt_db_internal *ip)
+emit_tessellated(const char *name, struct rt_db_internal *UNUSED(ip))
 {
     struct model *m;
     struct nmgregion *r;
     struct shell *s;
     struct rt_bot_internal *bot;
+    struct rt_db_internal tess_intern;
+    struct directory *dp;
     const struct rt_functab *ftp;
 
-    ftp = ip->idb_meth;
+    /* Re-read the primitive from the database for a fresh copy */
+    dp = db_lookup(dbip, name, LOOKUP_QUIET);
+    if (dp == RT_DIR_NULL) {
+	bu_log("WARNING: cannot re-read %s for tessellation\n", name);
+	return;
+    }
+    if (rt_db_get_internal(&tess_intern, dp, dbip, NULL, &rt_uniresource) < 0) {
+	bu_log("WARNING: cannot re-read %s for tessellation\n", name);
+	return;
+    }
+
+    ftp = tess_intern.idb_meth;
     if (!ftp || !ftp->ft_tessellate) {
 	bu_log("WARNING: no tessellation method for %s, skipping\n", name);
+	rt_db_free_internal(&tess_intern);
 	return;
     }
 
     m = nmg_mm();
-    if (ftp->ft_tessellate(&r, m, ip, &ttol, &tol) < 0) {
+    if (ftp->ft_tessellate(&r, m, &tess_intern, &ttol, &tol) < 0) {
 	bu_log("WARNING: tessellation failed for %s, skipping\n", name);
 	nmg_km(m);
+	rt_db_free_internal(&tess_intern);
 	return;
     }
 
@@ -475,9 +496,12 @@ emit_tessellated(const char *name, struct rt_db_internal *ip)
 	BU_LIST_INIT(&vlfree);
 	bot = nmg_bot(s, &vlfree, &tol);
     }
+
+    nmg_km(m);
+    rt_db_free_internal(&tess_intern);
+
     if (!bot || bot->num_faces == 0) {
 	bu_log("WARNING: empty tessellation for %s, skipping\n", name);
-	nmg_km(m);
 	return;
     }
 
@@ -486,7 +510,6 @@ emit_tessellated(const char *name, struct rt_db_internal *ip)
 	       name, bot->num_vertices, bot->num_faces);
 
     emit_bot(bot);
-    nmg_km(m);
 }
 
 

--- a/src/conv/csg/g-scad.c
+++ b/src/conv/csg/g-scad.c
@@ -683,6 +683,251 @@ emit_object(const char *name)
 		    break;
 		}
 
+	    case ID_PARTICLE:
+		{
+		    /*
+		     * Particle: lozenge/capsule shape defined by two
+		     * endpoints with radii.  Map to hull of two spheres.
+		     */
+		    struct rt_part_internal *part = (struct rt_part_internal *)intern.idb_ptr;
+		    point_t end_pt;
+
+		    VADD2(end_pt, part->part_V, part->part_H);
+
+		    print_indent();
+		    fprintf(fd_out, "hull() {\n");
+		    indent_level++;
+		    print_indent();
+		    fprintf(fd_out, "translate([%g, %g, %g])\n", V3ARGS(part->part_V));
+		    indent_level++;
+		    print_indent();
+		    fprintf(fd_out, "sphere(r = %g);\n", part->part_vrad);
+		    indent_level--;
+		    print_indent();
+		    fprintf(fd_out, "translate([%g, %g, %g])\n", V3ARGS(end_pt));
+		    indent_level++;
+		    print_indent();
+		    fprintf(fd_out, "sphere(r = %g);\n", part->part_hrad);
+		    indent_level--;
+		    indent_level--;
+		    print_indent();
+		    fprintf(fd_out, "}\n");
+		    solid_count++;
+		    break;
+		}
+
+	    case ID_PIPE:
+		{
+		    /*
+		     * Pipe: linked list of waypoints with outer/inner
+		     * diameters and bend radii.  Emit cylinders for
+		     * straight segments and tori for bends.
+		     */
+		    struct rt_pipe_internal *pipe_ip = (struct rt_pipe_internal *)intern.idb_ptr;
+		    struct wdb_pipe_pnt *pp, *prev;
+
+		    print_indent();
+		    fprintf(fd_out, "union() {\n");
+		    indent_level++;
+
+		    prev = NULL;
+		    for (BU_LIST_FOR(pp, wdb_pipe_pnt, &pipe_ip->pipe_segs_head)) {
+			if (prev) {
+			    vect_t seg_h;
+			    double seg_len;
+			    double r1 = prev->pp_od / 2.0;
+			    double r2 = pp->pp_od / 2.0;
+
+			    VSUB2(seg_h, pp->pp_coord, prev->pp_coord);
+			    seg_len = MAGNITUDE(seg_h);
+
+			    if (seg_len > tol.dist) {
+				vect_t h_unit, a_unit, b_unit;
+				mat_t m;
+
+				VSCALE(h_unit, seg_h, 1.0 / seg_len);
+				bn_vec_ortho(a_unit, h_unit);
+				VCROSS(b_unit, h_unit, a_unit);
+
+				MAT_ZERO(m);
+				m[0]  = a_unit[0]; m[4]  = b_unit[0]; m[8]  = h_unit[0]; m[12] = prev->pp_coord[0];
+				m[1]  = a_unit[1]; m[5]  = b_unit[1]; m[9]  = h_unit[1]; m[13] = prev->pp_coord[1];
+				m[2]  = a_unit[2]; m[6]  = b_unit[2]; m[10] = h_unit[2]; m[14] = prev->pp_coord[2];
+				m[15] = 1.0;
+
+				emit_matrix_open(m);
+				print_indent();
+				fprintf(fd_out, "cylinder(h = %g, r1 = %g, r2 = %g);\n",
+					seg_len, r1, r2);
+				emit_matrix_close(m);
+			    }
+
+			    /* Sphere at joint for smooth connection */
+			    print_indent();
+			    fprintf(fd_out, "translate([%g, %g, %g])\n",
+				    V3ARGS(prev->pp_coord));
+			    indent_level++;
+			    print_indent();
+			    fprintf(fd_out, "sphere(r = %g);\n", r1);
+			    indent_level--;
+
+			}
+			prev = pp;
+		    }
+
+		    /* End cap sphere */
+		    if (prev) {
+			print_indent();
+			fprintf(fd_out, "translate([%g, %g, %g])\n",
+				V3ARGS(prev->pp_coord));
+			indent_level++;
+			print_indent();
+			fprintf(fd_out, "sphere(r = %g);\n", prev->pp_od / 2.0);
+			indent_level--;
+		    }
+
+		    indent_level--;
+		    print_indent();
+		    fprintf(fd_out, "}\n");
+		    solid_count++;
+		    break;
+		}
+
+	    case ID_REVOLVE:
+		{
+		    /*
+		     * Revolve: a sketch revolved around an axis.
+		     * Maps to rotate_extrude(angle) polygon().
+		     */
+		    struct rt_revolve_internal *rev = (struct rt_revolve_internal *)intern.idb_ptr;
+		    struct rt_sketch_internal *skt = NULL;
+		    struct directory *skt_dp;
+		    struct rt_db_internal skt_intern;
+		    mat_t m;
+		    vect_t axis_unit, r_unit, cross;
+		    double ang_deg;
+
+		    skt_dp = db_lookup(dbip, bu_vls_cstr(&rev->sketch_name), LOOKUP_QUIET);
+		    if (skt_dp == RT_DIR_NULL) {
+			bu_log("WARNING: sketch '%s' not found for revolve %s\n",
+			       bu_vls_cstr(&rev->sketch_name), name);
+			emit_tessellated(name, &intern);
+			break;
+		    }
+		    if (rt_db_get_internal(&skt_intern, skt_dp, dbip, NULL, &rt_uniresource) < 0) {
+			bu_log("WARNING: failed to read sketch '%s'\n",
+			       bu_vls_cstr(&rev->sketch_name));
+			emit_tessellated(name, &intern);
+			break;
+		    }
+		    skt = (struct rt_sketch_internal *)skt_intern.idb_ptr;
+
+		    ang_deg = rev->ang * 180.0 / M_PI;
+		    if (ang_deg < 0.01)
+			ang_deg = 360.0;
+
+		    /* Build local frame: r = X, axis = Z */
+		    VMOVE(r_unit, rev->r);
+		    VUNITIZE(r_unit);
+		    VMOVE(axis_unit, rev->axis3d);
+		    VUNITIZE(axis_unit);
+		    VCROSS(cross, axis_unit, r_unit);
+		    VUNITIZE(cross);
+
+		    MAT_ZERO(m);
+		    m[0]  = r_unit[0];    m[4]  = cross[0];    m[8]  = axis_unit[0]; m[12] = rev->v3d[0];
+		    m[1]  = r_unit[1];    m[5]  = cross[1];    m[9]  = axis_unit[1]; m[13] = rev->v3d[1];
+		    m[2]  = r_unit[2];    m[6]  = cross[2];    m[10] = axis_unit[2]; m[14] = rev->v3d[2];
+		    m[15] = 1.0;
+
+		    emit_matrix_open(m);
+
+		    print_indent();
+		    if (NEAR_EQUAL(ang_deg, 360.0, 0.01))
+			fprintf(fd_out, "rotate_extrude() {\n");
+		    else
+			fprintf(fd_out, "rotate_extrude(angle = %g) {\n", ang_deg);
+		    indent_level++;
+
+		    /* Emit polygon from sketch */
+		    {
+			size_t vi, si;
+			int has_lines = 0;
+
+			print_indent();
+			fprintf(fd_out, "polygon(\n");
+			indent_level++;
+
+			print_indent();
+			fprintf(fd_out, "points = [\n");
+			indent_level++;
+			for (vi = 0; vi < skt->vert_count; vi++) {
+			    print_indent();
+			    fprintf(fd_out, "[%g, %g]%s\n",
+				    skt->verts[vi][0], skt->verts[vi][1],
+				    (vi < skt->vert_count - 1) ? "," : "");
+			}
+			indent_level--;
+			print_indent();
+			fprintf(fd_out, "],\n");
+
+			print_indent();
+			fprintf(fd_out, "paths = [\n");
+			indent_level++;
+
+			for (si = 0; si < skt->curve.count; si++) {
+			    uint32_t *magic_p = (uint32_t *)skt->curve.segment[si];
+			    if (*magic_p == CURVE_LSEG_MAGIC) {
+				has_lines = 1;
+				break;
+			    }
+			}
+
+			if (has_lines) {
+			    print_indent();
+			    fprintf(fd_out, "[");
+			    {
+				int first = 1;
+				for (si = 0; si < skt->curve.count; si++) {
+				    uint32_t *magic_p = (uint32_t *)skt->curve.segment[si];
+				    if (*magic_p == CURVE_LSEG_MAGIC) {
+					struct line_seg *lseg = (struct line_seg *)skt->curve.segment[si];
+					if (!first) fprintf(fd_out, ", ");
+					fprintf(fd_out, "%d", lseg->start);
+					first = 0;
+				    }
+				}
+			    }
+			    fprintf(fd_out, "]\n");
+			} else {
+			    print_indent();
+			    fprintf(fd_out, "[");
+			    for (vi = 0; vi < skt->vert_count; vi++) {
+				fprintf(fd_out, "%zu%s", vi,
+					(vi < skt->vert_count - 1) ? ", " : "");
+			    }
+			    fprintf(fd_out, "]\n");
+			}
+
+			indent_level--;
+			print_indent();
+			fprintf(fd_out, "]\n");
+
+			indent_level--;
+			print_indent();
+			fprintf(fd_out, ");\n");
+		    }
+
+		    indent_level--;
+		    print_indent();
+		    fprintf(fd_out, "}\n");
+
+		    emit_matrix_close(m);
+		    rt_db_free_internal(&skt_intern);
+		    solid_count++;
+		    break;
+		}
+
 	    case ID_HALF:
 		{
 		    /*


### PR DESCRIPTION
## Summary

Bidirectional OpenSCAD converters that preserve CSG structure:

- **csg-g** — imports OpenSCAD's evaluated `.csg` format into BRL-CAD `.g` files
- **g-scad** — exports BRL-CAD `.g` objects to `.scad` files

Both converters map primitives and boolean operations directly to their equivalents rather than tessellating to mesh, producing clean analytic geometry wherever possible.

## csg-g (OpenSCAD → BRL-CAD)

| .csg input | BRL-CAD output |
|---|---|
| `cube()` | RPP |
| `sphere()` | SPH |
| `cylinder()` | TGC |
| `polyhedron()` | ARB4/5/6/7/8 if convex match, else BOT |
| `rotate_extrude(circle())` | TOR |
| `linear_extrude(square())` | RPP |
| `linear_extrude(circle())` | TGC |
| `linear_extrude(polygon())` | sketch + extrusion |
| `import("file.stl")` | BOT (STL inlined during conversion) |
| `difference/union/intersection/group` | boolean combinations |
| `multmatrix()` | transformation matrix |
| `color()` | color/alpha attributes |
| `render()` | pass-through |

Polyhedron import detects all ARB types (4–8) with a convexity check — non-convex polyhedra fall back to BOT. Tetrahedra skip the convexity check since they're always convex.

## g-scad (BRL-CAD → OpenSCAD)

| BRL-CAD input | .scad output |
|---|---|
| SPH/ELL | `sphere()` + `multmatrix()` |
| TGC/REC | `cylinder()` + `multmatrix()` |
| ARB4–8 | `polyhedron()` (degenerate faces stripped) |
| BOT | `polyhedron()` |
| TOR | `rotate_extrude() circle()` |
| PARTICLE | `hull() { sphere(); sphere(); }` |
| PIPE | `union()` of cylinders + joint spheres |
| REVOLVE | `rotate_extrude(angle) polygon()` |
| EXTRUDE | `linear_extrude() polygon()` |
| HALF | `multmatrix() cube(2e10)` |
| combinations | `difference/union/intersection` |
| combination colors | `color()` |
| everything else | tessellated via `ft_tessellate` → `polyhedron()` |

Tessellation uses a fresh `rt_db_get_internal` copy to avoid heap corruption from `ft_tessellate` modifying the caller's internal.

## Usage

```sh
# OpenSCAD to BRL-CAD (two-step via .csg)
openscad -o model.csg model.scad
csg-g model.csg model.g

# BRL-CAD to OpenSCAD
g-scad -o model.scad model.g object_name
```

## Testing

Round-trip tested across 59 BRL-CAD sample models (.g → .scad → .csg → .g):

- **55 of 59** models completed the full circuit successfully
- **43 models** had zero warnings in both directions — lossless round-trip
- **4 timeouts** on large BREP/DSP tessellation (bishop, terra, 2 NIST models)
- All round-tripped `.scad` files verified to render in OpenSCAD
- `regress-repository` passes (API wrapper compliance)
- Full `ninja test` suite passes (1093/1095, 2 pre-existing non-issues)
- CI passes on Ubuntu GCC, MSVC Ninja, MSVC Standard Tools, macOS Clang

Solid count mismatches in round-trip are structural, not data loss:
- PIPE primitives expand to multiple cylinders+spheres in OpenSCAD (e.g., toyjeep 321→475)
- One `hull()` node (from PARTICLE) is not parsed back by csg-g

## Known Limitations

- `hull()` and `minkowski()` nodes in .csg are skipped (no CSG equivalent without shelling out to OpenSCAD)
- `linear_extrude` with `twist` parameter has no BRL-CAD equivalent
- Binary STL in `import()` not yet handled (ASCII only)
- Named hierarchy and region IDs are lost through the .csg format (OpenSCAD doesn't preserve them)
- Transforms get baked into primitives by OpenSCAD's .csg export — geometry is equivalent but representation differs
