### PR TITLE
Fix rt_db_put_internal for in-memory databases

### DIFF
--- a/src/librt/db5_alloc.c
+++ b/src/librt/db5_alloc.c
@@ -119,7 +119,7 @@ db5_realloc(struct db_i *dbip, struct directory *dp, struct bu_external *ep)
     baselen = dp->d_len;
 
     if (dp->d_flags & RT_DIR_INMEM) {
-	if (dp->d_un.ptr) {
+	if (dp->d_un.ptr && dp->d_addr != RT_DIR_PHONY_ADDR) {
 	    if (RT_G_DEBUG&RT_DEBUG_DB)
 		bu_log("db5_realloc(%s) bu_realloc()ing memory resident object\n", dp->d_namep);
 	    dp->d_un.ptr = bu_realloc(dp->d_un.ptr,
@@ -133,13 +133,19 @@ db5_realloc(struct db_i *dbip, struct directory *dp, struct bu_external *ep)
 	return 0;
     }
 
-    /* make sure the database directory is initialized */
-    if (dbip->i->dbi_eof == RT_DIR_PHONY_ADDR) {
-	int ret = db_dirbuild(dbip);
-	if (ret) {
-	    return -1;
+	/* make sure the database directory is initialized */
+	if (dbip->i->dbi_eof == RT_DIR_PHONY_ADDR) {
+		if (!dbip->i->dbi_fp) {
+			/* in-memory database has no file pointer - directory
+			* is already in memory, just mark it as initialized */
+			dbip->i->dbi_eof = 0;
+		} else {
+			int ret = db_dirbuild(dbip);
+			if (ret) {
+				return -1;
+			}
+		}
 	}
-    }
 
     if (dbip->dbi_read_only) {
 	bu_log("db5_realloc(%s) on READ-ONLY file\n", dp->d_namep);

--- a/src/librt/db_lookup.c
+++ b/src/librt/db_lookup.c
@@ -287,7 +287,11 @@ db_diradd(struct db_i *dbip, const char *name, b_off_t laddr, size_t len, int fl
     /* TODO: investigate removing exclusion of INMEM flag, added by
      * mike in c13285 when in-mem support was originally added
      */
-    dp->d_flags = flags & ~(RT_DIR_INMEM);
+    /* Preserve RT_DIR_INMEM flag if database is in-memory */
+	if (dbip->i->dbi_fp == NULL)
+		dp->d_flags = flags | RT_DIR_INMEM;
+	else
+		dp->d_flags = flags & ~(RT_DIR_INMEM);
     dp->d_len = len;
     dp->d_forw = *headp;
     BU_LIST_INIT(&dp->d_use_hd);

--- a/src/librt/tests/CMakeLists.txt
+++ b/src/librt/tests/CMakeLists.txt
@@ -77,6 +77,7 @@ brlcad_addexec(rt_bv_poly_sketch bv_poly_sketch.c "librt;libbv" TEST)
 # arb8 testing
 brlcad_addexec(rt_arb8 arb8_tests.c "librt;libwdb;libbg;libbu" TEST)
 #brlcad_add_test(NAME rt_arb8_tests COMMAND rt_arb8)
+brlcad_addexec(rt_inmem inmem_tests.c "librt;libwdb;libbg;libbu" TEST)
 
 # search stress and correctness testing
 brlcad_addexec(rt_search_stress search_stress.c "librt;libwdb;libbu" TEST)

--- a/src/librt/tests/inmem_tests.c
+++ b/src/librt/tests/inmem_tests.c
@@ -1,0 +1,65 @@
+/*                  I N M E M _ T E S T S . C
+ * BRL-CAD
+ *
+ * Copyright (c) 2026 United States Government as represented by
+ * the U.S. Army Research Laboratory.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ */
+/** @file inmem_tests.c
+ *
+ * Regression test for rt_db_put_internal() with in-memory databases.
+ * Bug report: https://github.com/BRL-CAD/brlcad/issues/864
+ */
+#include "common.h"
+#include <stdio.h>
+#include "bu.h"
+#include "vmath.h"
+#include "wdb.h"
+#include "raytrace.h"
+
+int
+main(int argc, char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    /* exactly the bug reporter's code */
+    struct db_i *db = db_create_inmem();
+
+    struct rt_ell_internal *sph = NULL;
+    BU_ALLOC(sph, struct rt_ell_internal);
+    sph->magic = RT_ELL_INTERNAL_MAGIC;
+    VSET(sph->v, 0, 0, 0);
+    VSET(sph->a, 1, 0, 0);
+    VSET(sph->b, 0, 1, 0);
+    VSET(sph->c, 0, 0, 1);
+
+    struct rt_db_internal in;
+    RT_DB_INTERNAL_INIT(&in);
+    in.idb_major_type = DB5_MAJORTYPE_BRLCAD;
+    in.idb_minor_type = ID_SPH;
+    in.idb_meth = &OBJ[ID_SPH];
+    in.idb_ptr = sph;
+
+    unsigned char minor_type = ID_SPH;
+    struct directory *dir = db_diradd(db, "sph.o", RT_DIR_PHONY_ADDR, 0, RT_DIR_SOLID, &minor_type);
+    int ret = rt_db_put_internal(dir, db, &in, &rt_uniresource);
+
+    if (ret < 0) {
+        bu_log("FAIL: rt_db_put_internal() returned %d\n", ret);
+        db_close(db);
+        return 1;
+    }
+
+    bu_log("PASS: rt_db_put_internal works with inmem database\n");
+    db_close(db);
+    return 0;
+}

--- a/src/librt/tests/inmem_tests.c
+++ b/src/librt/tests/inmem_tests.c
@@ -16,7 +16,7 @@
 /** @file inmem_tests.c
  *
  * Regression test for rt_db_put_internal() with in-memory databases.
- * Bug report: https://github.com/BRL-CAD/brlcad/issues/864
+ * Bug report: https://github.com/BRL-CAD/brlcad/issues/161
  */
 #include "common.h"
 #include <stdio.h>


### PR DESCRIPTION
Fixes #161 
db_diradd was stripping the RT_DIR_INMEM flag causing writes to attempt file I/O on a NULL file pointer. db5_realloc was calling db_dirbuild which always fails for inmem databases since there is no file pointer. Fixed both issues and added a regression test.
I tested it with the code the bug reporter sent and arbalest:
<img width="840" height="437" alt="image" src="https://github.com/user-attachments/assets/585c3d36-665e-4839-b8cc-5431d03a2f03" />

