### PR TITLE
Fix typo in GeometryIO.tcl which causes model exports to fail

### DIFF
--- a/src/tclscripts/lib/GeometryIO.tcl
+++ b/src/tclscripts/lib/GeometryIO.tcl
@@ -176,7 +176,7 @@ proc geom_load {input_file gui_feedback} {
 # and may only want a subset.
 proc geom_save {input_file output_file db_component} {
 
-    set binpath [bu_dir bin] ]
+    set binpath [bu_dir bin]
 
     set output_filename [file tail $output_file]
     set output_dir [file dirname $output_file]


### PR DESCRIPTION
Using the `File->Export` function in archer causes the following error (same behavior in both Windows and Linux):

```
wrong # args: should be "set varName ?newValue?"
    while executing
"set binpath [bu_dir bin] ]"
    (procedure "cadwidgets::geom_save" line 3)
    invoked from within
"cadwidgets::geom_save $mTargetCopy $mTarget $itk_component(ged)"
    (object "::.archer0" method "::ArcherCore::exportDb" body line 21)
    invoked from within
"::.archer0 exportDb"
    (in namespace inscope "::Archer" script line 1)
    invoked from within
"namespace inscope ::Archer {::.archer0 exportDb}"
    (menu invoke)
```

Turns out to be a typo in `GeometryIO.tcl`.