### PR TITLE
Only call set_target_properties on perm-test when testing is enabled

### DIFF
--- a/src/tclscripts/CMakeLists.txt
+++ b/src/tclscripts/CMakeLists.txt
@@ -139,7 +139,9 @@ if(TARGET btclsh)
   )
   add_custom_target(TclIndexBld ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tclindexbld.sentinel)
   distclean(${CMAKE_CURRENT_BINARY_DIR}/tclindexbld.sentinel)
-  set_target_properties(perm_test PROPERTIES FOLDER "Compilation Utilities")
+  if(BUILD_TESTING)
+    set_target_properties(perm_test PROPERTIES FOLDER "Compilation Utilities")
+  endif()
 
   foreach(ifile ${index_install_files})
     # Install logic for index file.


### PR DESCRIPTION
Otherwise CMake will complain if `BUILD_TESTING` is false:

```
CMake Error at src/tclscripts/CMakeLists.txt:142 (set_target_properties):
  set_target_properties Can not find target to add properties to: perm_test
```