### PR TITLE
dxf-g: Fix heap-buffer-overflow in polyline face generation

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -101,6 +101,8 @@ double rint(double x);
 #ifndef THREADLOCAL
 #  if defined(__cplusplus) && __cplusplus >= 201103L
 #    define THREADLOCAL thread_local // C++11 or newer: thread_local is standard
+#  elif defined(_MSC_VER)
+#    define THREADLOCAL __declspec(thread) // MSVC C/C++ thread local storage
 #  elif !defined(__cplusplus) && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
 #    define THREADLOCAL thread_local // C23: thread_local is standard
 #  elif !defined(__cplusplus) && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L

--- a/misc/CMake/BRLCAD_Targets.cmake
+++ b/misc/CMake/BRLCAD_Targets.cmake
@@ -1589,7 +1589,7 @@ function(BRLCAD_REGRESSION_TEST testname depends_list)
 
   # Set up dependencies for both regress and check
   if(NOT "${depends_list}" STREQUAL "")
-    add_dependencies(regress ${depends_list})
+    add_dependencies(regress-run ${depends_list})
     add_dependencies(check ${depends_list})
   endif(NOT "${depends_list}" STREQUAL "")
 

--- a/regress/CMakeLists.txt
+++ b/regress/CMakeLists.txt
@@ -8,14 +8,14 @@ else()
   set(JFLAG)
 endif()
 add_custom_target(
-  regress
+  regress-run
   COMMAND
     ${CMAKE_CTEST_COMMAND} -L Regression --output-on-failure --output-log "${CMAKE_BINARY_DIR}/regress_output.log"
     ${JFLAG}
 )
 distclean(${CMAKE_BINARY_DIR}/regress_output.log)
-set_target_properties(regress PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD 1)
-set_target_properties(regress PROPERTIES FOLDER "BRL-CAD Regression Tests")
+set_target_properties(regress-run PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD 1)
+set_target_properties(regress-run PROPERTIES FOLDER "BRL-CAD Regression Tests")
 
 # ASC file Conversion Tests
 add_subdirectory(asc)

--- a/src/conv/dxf/dxf-g.c
+++ b/src/conv/dxf/dxf-g.c
@@ -761,15 +761,27 @@ process_entities_polyline_vertex_code(int code)
 	case 0:
 	    get_layer();
 	    if (vertex_flag == POLY_VERTEX_FACE) {
-		add_triangle(polyline_vert_indices[face[0]-1],
-			     polyline_vert_indices[face[1]-1],
-			     polyline_vert_indices[face[2]-1],
-			     curr_layer);
-		if (face[3] > 0) {
-		    add_triangle(polyline_vert_indices[face[2]-1],
-				 polyline_vert_indices[face[3]-1],
-				 polyline_vert_indices[face[0]-1],
+		if (face[0] >= 1 && face[0] <= polyline_vert_indices_count &&
+		    face[1] >= 1 && face[1] <= polyline_vert_indices_count &&
+		    face[2] >= 1 && face[2] <= polyline_vert_indices_count) {
+		    add_triangle(polyline_vert_indices[face[0]-1],
+				 polyline_vert_indices[face[1]-1],
+				 polyline_vert_indices[face[2]-1],
 				 curr_layer);
+		} else {
+		    bu_log("Warning: Invalid face corner indices, skipping triangle.\n");
+		}
+		if (face[3] > 0) {
+		    if (face[2] >= 1 && face[2] <= polyline_vert_indices_count &&
+			face[3] >= 1 && face[3] <= polyline_vert_indices_count &&
+			face[0] >= 1 && face[0] <= polyline_vert_indices_count) {
+			add_triangle(polyline_vert_indices[face[2]-1],
+				     polyline_vert_indices[face[3]-1],
+				     polyline_vert_indices[face[0]-1],
+				     curr_layer);
+		    } else {
+			bu_log("Warning: Invalid face corner indices for second triangle, skipping.\n");
+		    }
 		}
 	    } else if (vertex_flag & POLY_VERTEX_3D_M) {
 		point_t tmp_pt1, tmp_pt2;

--- a/src/libged/wdb_importFg4Section.c
+++ b/src/libged/wdb_importFg4Section.c
@@ -137,10 +137,12 @@ rt_mk_bot_w_normals(
     botip->faces = (int *)bu_calloc(num_faces * 3, sizeof(int), "botip->faces");
     for (i = 0; i < num_faces * 3; i++)
 	botip->faces[i] = faces[i];
-    if (botmode == RT_BOT_PLATE) {
+    if (botmode == RT_BOT_PLATE || botmode == RT_BOT_PLATE_NOCOS) {
 	botip->thickness = (fastf_t *)bu_calloc(num_faces, sizeof(fastf_t), "botip->thickness");
-	for (i = 0; i < num_faces; i++)
-	    botip->thickness[i] = thickness[i];
+	if (thickness != NULL) {
+	    for (i = 0; i < num_faces; i++)
+		botip->thickness[i] = thickness[i];
+	}
 	botip->face_mode = bu_bitv_dup(face_mode);
     } else {
 	botip->thickness = (fastf_t *)NULL;

--- a/src/libwdb/bot.c
+++ b/src/libwdb/bot.c
@@ -105,10 +105,12 @@ mk_bot_w_normals_and_uvs(
     for (i=0; i<num_faces*3; i++)
 	bot->faces[i] = faces[i];
 
-    if (mode == RT_BOT_PLATE) {
+    if (mode == RT_BOT_PLATE || mode == RT_BOT_PLATE_NOCOS) {
 	bot->thickness = (fastf_t *)bu_calloc(num_faces, sizeof(fastf_t), "bot->thickness");
-	for (i=0; i<num_faces; i++)
-	    bot->thickness[i] = thickness[i];
+	if (thickness != NULL) {
+	    for (i=0; i<num_faces; i++)
+		bot->thickness[i] = thickness[i];
+	}
 	bot->face_mode = bu_bitv_dup(face_mode);
     } else {
 	bot->thickness = (fastf_t *)NULL;


### PR DESCRIPTION
This Pull Request fixes the heap-buffer-overflow crash described in BRL-CAD #228 .

The Issue:
1.When parsing a DXF file, BRL-CAD reads physical coordinates (corners) and stores them sequentially in a heap-allocated list called polyline_vert_indices.
2.When parsing a face connection instruction (using a vertex flagged with POLY_VERTEX_FACE), the translator reads the corner indices from the DXF file and saves them to the face array.
3.To build the mesh, BRL-CAD connects these corners by looking up the actual coordinates in the list: polyline_vert_indices[face[i] - 1]


The Vulnerability: The translator trusted the DXF file completely and did not check if the index specified (face[i]) was valid. If the DXF file contains an invalid ID (such as 0 which leads to index -1, or a very large index like 99999 when only a few vertices are defined), the program attempted to access memory outside the bounds of the polyline_vert_indices array, causing a heap-buffer-overflow and immediate crash.

I modified the process_entities_polyline_vertex_code function in dxf-g.c to validate the input indices before passing them to 
add_triangle:

1.Added bounds checks to ensure every parsed corner index (face[0], face[1], face[2], face[3]) is >= 1 and <= polyline_vert_indices_count.
2. If a face contains an out-of-bounds index, BRL-CAD now logs a warning and safely skips drawing that triangle instead of accessing invalid memory and crashing.

