### PR TITLE
libwdb, libged: fix mk_bot crash in RT_BOT_PLATE_NOCOS mode

### DIFF
--- a/src/libged/wdb_importFg4Section.c
+++ b/src/libged/wdb_importFg4Section.c
@@ -137,10 +137,12 @@ rt_mk_bot_w_normals(
     botip->faces = (int *)bu_calloc(num_faces * 3, sizeof(int), "botip->faces");
     for (i = 0; i < num_faces * 3; i++)
 	botip->faces[i] = faces[i];
-    if (botmode == RT_BOT_PLATE) {
+    if (botmode == RT_BOT_PLATE || botmode == RT_BOT_PLATE_NOCOS) {
 	botip->thickness = (fastf_t *)bu_calloc(num_faces, sizeof(fastf_t), "botip->thickness");
-	for (i = 0; i < num_faces; i++)
-	    botip->thickness[i] = thickness[i];
+	if (thickness != NULL) {
+	    for (i = 0; i < num_faces; i++)
+		botip->thickness[i] = thickness[i];
+	}
 	botip->face_mode = bu_bitv_dup(face_mode);
     } else {
 	botip->thickness = (fastf_t *)NULL;

--- a/src/libwdb/bot.c
+++ b/src/libwdb/bot.c
@@ -105,10 +105,12 @@ mk_bot_w_normals_and_uvs(
     for (i=0; i<num_faces*3; i++)
 	bot->faces[i] = faces[i];
 
-    if (mode == RT_BOT_PLATE) {
+    if (mode == RT_BOT_PLATE || mode == RT_BOT_PLATE_NOCOS) {
 	bot->thickness = (fastf_t *)bu_calloc(num_faces, sizeof(fastf_t), "bot->thickness");
-	for (i=0; i<num_faces; i++)
-	    bot->thickness[i] = thickness[i];
+	if (thickness != NULL) {
+	    for (i=0; i<num_faces; i++)
+		bot->thickness[i] = thickness[i];
+	}
 	bot->face_mode = bu_bitv_dup(face_mode);
     } else {
 	bot->thickness = (fastf_t *)NULL;


### PR DESCRIPTION
# Fix mk_bot crash in RT_BOT_PLATE_NOCOS mode

### What happened (The Issue)
When creating a Bag of Triangles (BOT) shape with the mode `RT_BOT_PLATE_NOCOS`, BRL-CAD crashed during the export phase (specifically when saving the shape to a database).

The root cause was a mismatch in how `RT_BOT_PLATE_NOCOS` was handled: the creation helpers in `libwdb` only allocated a thickness array for the `RT_BOT_PLATE` mode, leaving it `NULL` for `RT_BOT_PLATE_NOCOS`. However, the exporter expected `RT_BOT_PLATE_NOCOS` to have a valid thickness array, causing a NULL pointer dereference crash.

### What I did (The Fix)
Updated the BOT creation functions `mk_bot_w_normals_and_uvs` in [src/libwdb/bot.c](file:///c:/Users/HP/brlcad/src/libwdb/bot.c) and `rt_mk_bot_w_normals` in [src/libged/wdb_importFg4Section.c](file:///c:/Users/HP/brlcad/src/libged/wdb_importFg4Section.c) to allocate the thickness array when the mode is `RT_BOT_PLATE` or `RT_BOT_PLATE_NOCOS`. Added a safety check to set elements to zero if a `NULL` thickness argument is provided.

Closes Issue #223 
